### PR TITLE
✨ feat(feed): add RSS feed endpoint and wire module

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,84 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "entire hooks claude-code session-start"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "entire hooks claude-code session-end"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "entire hooks claude-code user-prompt-submit"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "entire hooks claude-code stop"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "entire hooks claude-code pre-task"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "entire hooks claude-code post-task"
+          }
+        ]
+      },
+      {
+        "matcher": "TodoWrite",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "entire hooks claude-code post-todo"
+          }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "deny": [
+      "Read(./.entire/metadata/**)"
+    ]
+  }
+}

--- a/.claude/skills/github-issues-first/SKILL.md
+++ b/.claude/skills/github-issues-first/SKILL.md
@@ -15,7 +15,10 @@ description: Use when the user asks to implement features, fix bugs, or make any
 NO CODE WITHOUT A GITHUB ISSUE FIRST
 ```
 
-Before writing ANY code - even a one-line fix - create a GitHub issue that describes what you're doing and why.
+Before writing ANY code - even a one-line fix do the following: 
+
+1. Check if a GitHub issue already exists for the change you want to make.
+2. If no issue exists, create a GitHub issue that describes what you're doing and why.
 
 **Violating the letter of this rule is violating the spirit of this rule.**
 

--- a/.entire/.gitignore
+++ b/.entire/.gitignore
@@ -1,0 +1,4 @@
+tmp/
+settings.local.json
+metadata/
+logs/

--- a/.entire/settings.json
+++ b/.entire/settings.json
@@ -1,0 +1,5 @@
+{
+  "strategy": "manual-commit",
+  "enabled": true,
+  "telemetry": true
+}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@nestjs/mapped-types": "*",
     "@nestjs/platform-express": "^11.1.13",
     "@supabase/supabase-js": "^2.95.3",
+    "feed": "^5.2.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2"
   },
@@ -71,6 +72,9 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+      "^(\\.\\.?/.+)\\.js$": "$1"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.95.3
         version: 2.95.3
+      feed:
+        specifier: ^5.2.0
+        version: 5.2.0
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1816,6 +1819,10 @@ packages:
       picomatch:
         optional: true
 
+  feed@5.2.0:
+    resolution: {integrity: sha512-hgH6CCb+7+0c8PBlakI2KubG6R+Rb1MhpNcdvqUXZTBwBHf32piwY255diAkAmkGZ6AWlywOU88AkOgP9q8Rdw==}
+    engines: {node: '>=20', pnpm: '>=10'}
+
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
@@ -2719,6 +2726,10 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  sax@1.4.4:
+    resolution: {integrity: sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==}
+    engines: {node: '>=11.0.0'}
+
   schema-utils@3.3.0:
     resolution: {integrity: sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==}
     engines: {node: '>= 10.13.0'}
@@ -3178,6 +3189,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xml-js@1.6.11:
+    resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
+    hasBin: true
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -5110,6 +5125,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  feed@5.2.0:
+    dependencies:
+      xml-js: 1.6.11
+
   fetch-blob@3.2.0:
     dependencies:
       node-domexception: 1.0.0
@@ -6158,6 +6177,8 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  sax@1.4.4: {}
+
   schema-utils@3.3.0:
     dependencies:
       '@types/json-schema': 7.0.15
@@ -6665,6 +6686,10 @@ snapshots:
       signal-exit: 4.1.0
 
   ws@8.19.0: {}
+
+  xml-js@1.6.11:
+    dependencies:
+      sax: 1.4.4
 
   xtend@4.0.2: {}
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,12 +4,14 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { SupabaseModule } from './supabase/supabase.module.js';
 import { LinksModule } from './links/links.module';
+import { FeedModule } from './feed/feed.module';
 
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
     SupabaseModule,
     LinksModule,
+    FeedModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/feed/feed.controller.ts
+++ b/src/feed/feed.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get, Header } from '@nestjs/common';
+import { FeedService } from './feed.service';
+
+@Controller('feed')
+export class FeedController {
+  constructor(private readonly feedService: FeedService) {}
+
+  @Get()
+  @Header('Content-Type', 'application/rss+xml')
+  async getFeed(): Promise<string> {
+    return this.feedService.generateRssFeed();
+  }
+}

--- a/src/feed/feed.module.ts
+++ b/src/feed/feed.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { LinksModule } from '../links/links.module';
+import { FeedController } from './feed.controller';
+import { FeedService } from './feed.service';
+
+@Module({
+  imports: [LinksModule],
+  controllers: [FeedController],
+  providers: [FeedService],
+})
+export class FeedModule {}

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+import { Feed } from 'feed';
+import { LinksService } from '../links/links.service';
+
+@Injectable()
+export class FeedService {
+  constructor(private readonly linksService: LinksService) {}
+
+  async generateRssFeed(): Promise<string> {
+    const links = await this.linksService.findAll();
+
+    const feed = new Feed({
+      title: 'Linkblog',
+      description: 'Links worth reading',
+      id: 'https://luther.io/blogroll',
+      link: 'https://luther.io/blogroll',
+      language: 'en',
+      copyright: '',
+    });
+
+    for (const link of links ?? []) {
+      feed.addItem({
+        title: link.title,
+        id: link.url,
+        link: link.url,
+        description: link.summary ?? '',
+        date: new Date(link.created_at),
+      });
+    }
+
+    return feed.rss2();
+  }
+}

--- a/src/links/links.module.ts
+++ b/src/links/links.module.ts
@@ -5,5 +5,6 @@ import { LinksController } from './links.controller';
 @Module({
   controllers: [LinksController],
   providers: [LinksService],
+  exports: [LinksService],
 })
 export class LinksModule {}

--- a/src/links/links.service.spec.ts
+++ b/src/links/links.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { LinksService } from './links.service';
-import { SUPABASE_CLIENT } from '../supabase/supabase.module.js';
+import { SUPABASE_CLIENT } from '../supabase/supabase.module.ts';
 
 const mockSupabaseClient = {
   from: jest.fn().mockReturnThis(),


### PR DESCRIPTION
- Add Feed module, controller, and service to expose an RSS endpoint at /feed
- Controller sets Content-Type to application/rss+xml and delegates generation to FeedService
- Export LinksService from LinksModule so FeedService can reuse link data
- Import FeedModule into AppModule
- Add feed package and lockfile entries
- Configure Jest moduleNameMapper to map compiled .js test imports back to .ts
- Fix Supabase import path typo in links service tests
- Add .gitignore entries for tmp/, settings.local.json, metadata/, and logs
- Update contributor checklist to require checking/creating a GitHub issue before coding and add tool settings in .entire/settings.json