### PR TITLE
✨ docs: convert pages to Minimal Mistakes layout and update site config

### DIFF
--- a/github_pages/Gemfile
+++ b/github_pages/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "github-pages", group: :jekyll_plugins
+gem "jekyll-include-cache", group: :jekyll_plugins

--- a/github_pages/_config.yml
+++ b/github_pages/_config.yml
@@ -1,25 +1,22 @@
+remote_theme: "mmistakes/minimal-mistakes"
+minimal_mistakes_skin: "air"
+
 title: Linkblog
+subtitle: "API Documentation"
 description: A personal bookmarking API that publishes an RSS feed
 url: https://www.linkblog.in
-baseurl: ''
+baseurl: ""
 
-#remote_theme: "mmistakes/minimal-mistakes"
-#markdown: kramdown
-#highlighter: rouge
+markdown: kramdown
+highlighter: rouge
 
-## Minimal Mistakes configuration
-breadcrumbs: true  # disabled by default
+plugins:
+  - jekyll-include-cache
 
-nav:
-  - title: Home
-    url: /
-  - title: Getting Started
-    url: /getting-started
-  - title: API Reference
-    url: /api
-  - title: Architecture
-    url: /architecture
-  - title: Deployment
-    url: /deployment
-  - title: Implementation Plan
-    url: /implementation-plan
+breadcrumbs: true
+
+defaults:
+  - scope:
+      path: ""
+    values:
+      layout: "single"

--- a/github_pages/_data/navigation.yml
+++ b/github_pages/_data/navigation.yml
@@ -1,0 +1,11 @@
+main:
+  - title: "Home"
+    url: /
+  - title: "Getting Started"
+    url: /getting-started
+  - title: "API Reference"
+    url: /api
+  - title: "Architecture"
+    url: /architecture
+  - title: "Deployment"
+    url: /deployment

--- a/github_pages/api.md
+++ b/github_pages/api.md
@@ -1,6 +1,7 @@
 ---
-layout: default
+layout: single
 title: API Reference
+toc: true
 ---
 
 # API Reference
@@ -19,9 +20,7 @@ x-api-key: your-api-key
 
 The key is compared against the `API_KEY` environment variable. Requests with a missing or incorrect key receive a `401 Unauthorized` response.
 
-Read endpoints (`GET /links`, `GET /links/:id`) are also protected by the API key.
-
-The RSS feed (`GET /feed`) and health check (`GET /health`) are **public**.
+Read endpoints (`GET /links`, `GET /links/:id`), the RSS feed (`GET /feed`), and the health check (`GET /health`) are **public** — no API key required.
 
 ---
 
@@ -91,10 +90,10 @@ curl -X POST http://localhost:3000/links \
 
 List all links, sorted by newest first.
 
-**Auth:** `x-api-key` header required
+**Auth:** None
 
 ```bash
-curl -H "x-api-key: your-api-key" http://localhost:3000/links
+curl http://localhost:3000/links
 ```
 
 **Response:** `200 OK`
@@ -126,10 +125,10 @@ curl -H "x-api-key: your-api-key" http://localhost:3000/links
 
 Get a single link by ID.
 
-**Auth:** `x-api-key` header required
+**Auth:** None
 
 ```bash
-curl -H "x-api-key: your-api-key" http://localhost:3000/links/1
+curl http://localhost:3000/links/1
 ```
 
 **Response:** `200 OK`

--- a/github_pages/architecture.md
+++ b/github_pages/architecture.md
@@ -1,6 +1,7 @@
 ---
-layout: default
+layout: single
 title: Architecture
+toc: true
 ---
 
 # Architecture

--- a/github_pages/deployment.md
+++ b/github_pages/deployment.md
@@ -1,6 +1,7 @@
 ---
-layout: default
+layout: single
 title: Deployment
+toc: true
 ---
 
 # Deployment

--- a/github_pages/getting-started.md
+++ b/github_pages/getting-started.md
@@ -1,6 +1,7 @@
 ---
-layout: default
+layout: single
 title: Getting Started
+toc: true
 ---
 
 # Getting Started
@@ -110,8 +111,8 @@ Once the server is running:
 # Health check
 curl http://localhost:3000/health
 
-# List links (requires API key)
-curl -H "x-api-key: your-api-key" http://localhost:3000/links
+# List links (public)
+curl http://localhost:3000/links
 
 # RSS feed (public)
 curl http://localhost:3000/feed

--- a/github_pages/index.md
+++ b/github_pages/index.md
@@ -1,6 +1,6 @@
 ---
-layout: default
-title: Home
+layout: home
+title: Linkblog
 ---
 
 # Linkblog


### PR DESCRIPTION
Switch site pages to the Minimal Mistakes "single" layout, enable
per-page table of contents, and set the home layout to the theme's
home layout. Add a navigation data file and a Gemfile to load the
github-pages theme and jekyll-include-cache plugin.

Clarify API docs: mark list and get endpoints, RSS feed and health
check as public (no API key required) and update example curl calls.

Update _config.yml to use the remote_theme, skin, markdown/highlighter,
include the jekyll plugin, enable breadcrumbs, and set default layout
to "single" so pages inherit the new layout.

These changes modernize the site layout, improve navigation, simplify
config management, and correct API documentation to reflect public
endpoints.