### PR TITLE
✨ feat(docs): remove redundant top-level headings from pages

### DIFF
--- a/github_pages/api.md
+++ b/github_pages/api.md
@@ -4,8 +4,6 @@ title: API Reference
 toc: true
 ---
 
-# API Reference
-
 Base URL: `http://localhost:3000` (local) or your deployed App Runner URL.
 
 > **Tip:** A ready-to-use Postman collection is available in `postman/collection.json` with pre-built requests, test scripts, and a CRUD workflow runner. See [Getting Started](getting-started#using-postman) for setup.

--- a/github_pages/architecture.md
+++ b/github_pages/architecture.md
@@ -4,8 +4,6 @@ title: Architecture
 toc: true
 ---
 
-# Architecture
-
 ## Overview
 
 Linkblog is a single-purpose API service. There is no frontend — it is designed to be called by scripts, shortcuts, or other services. The public RSS feed is consumed by [luther.io](https://luther.io) at build time.

--- a/github_pages/deployment.md
+++ b/github_pages/deployment.md
@@ -4,8 +4,6 @@ title: Deployment
 toc: true
 ---
 
-# Deployment
-
 Linkblog is designed to run on **AWS App Runner** via Docker. This page covers building the image, configuring the environment, and deploying.
 
 ## Docker

--- a/github_pages/getting-started.md
+++ b/github_pages/getting-started.md
@@ -4,8 +4,6 @@ title: Getting Started
 toc: true
 ---
 
-# Getting Started
-
 ## Prerequisites
 
 - **Node.js** 20+ and **pnpm**

--- a/github_pages/index.md
+++ b/github_pages/index.md
@@ -3,7 +3,6 @@ layout: home
 title: Linkblog
 ---
 
-# Linkblog
 
 A personal bookmarking API built with **NestJS**, **TypeScript**, and **Supabase**. It stores articles with notes and publishes them as a public **RSS 2.0 feed** for the blogroll at [luther.io/blogroll](https://luther.io/blogroll).
 


### PR DESCRIPTION
Remove duplicated H1 titles from several GitHub Pages markdown files
(github_pages/deployment.md, index.md, architecture.md, api.md,
getting-started.md). The pages already include frontmatter title fields,
so the explicit top-level headings were redundant and caused
visual/semantic duplication in generated site output. Cleaning these
headings simplifies the source, prevents double titles in the rendered
site, and keeps content consistent with frontmatter-driven templates.