### PR TITLE
✨ Improve GitHub Pages configuration formatting

### DIFF
--- a/github_pages/_config.yml
+++ b/github_pages/_config.yml
@@ -1,11 +1,11 @@
-remote_theme: "mmistakes/minimal-mistakes"
-minimal_mistakes_skin: "air"
+# remote_theme: "mmistakes/minimal-mistakes"
+# minimal_mistakes_skin: "air"
 
 title: Linkblog
-subtitle: "API Documentation"
+subtitle: 'API Documentation'
 description: A personal bookmarking API that publishes an RSS feed
 url: https://www.linkblog.in
-baseurl: ""
+baseurl: ''
 
 markdown: kramdown
 highlighter: rouge
@@ -17,6 +17,6 @@ breadcrumbs: true
 
 defaults:
   - scope:
-      path: ""
+      path: ''
     values:
-      layout: "single"
+      layout: 'single'


### PR DESCRIPTION
Switch quote style from double to single quotes for consistency
across all string values in the Jekyll configuration. Comment out
the remote theme settings as they appear to be temporarily disabled.
These changes improve code style consistency throughout the config
file.