### PR TITLE
📝 docs: update deployment docs and add Supabase migration guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ See `docs/implementation-plan.md` for the full implementation plan and architect
 - **Endpoints:** `/links` (CRUD; reads public, writes protected), `/feed` (public RSS 2.0), `/health` (public)
 - **Auth:** Single-user, global `ApiKeyGuard` via `APP_GUARD`. Write endpoints require `x-api-key` header matching `API_KEY` env var. Public routes use `@Public()` decorator to opt out. See `src/auth/`.
 - **Data model:** `links` table in Supabase (id, url, title, summary, created_at, updated_at)
-- **Deploy:** AWS App Runner via source code (`apprunner.yaml`)
+- **Deploy:** AWS App Runner (manual console config; `apprunner.yaml` is reference only). Production URL: `api.linkblog.in`
 
 ## Commands
 
@@ -57,6 +57,7 @@ AppModule
 
 - All code changes must reference a GitHub issue. Check `gh issue list` before starting work.
 - Use `oxlint` for linting and formatting.
+- CI runs on PRs to `main` (`.github/workflows/ci.yml`): install, lint, fmt:check, build, test.
 
 ## Testing (Jest)
 
@@ -74,6 +75,7 @@ AppModule
 
 ## Gotchas
 
+- App Runner "config from repository" mode hides the env var UI in console. Use manual config to set secrets.
 - Use `pnpx` (not `npx`) for one-off package execution — matches `pnpm` package manager.
 - `but commit` uses `-p <cli-id>` (or `--changes`) to commit specific files, not `--files` or `-F`.
 - GitHub repo: `vidluther/linkblog` - use with `gh` commands.

--- a/README.md
+++ b/README.md
@@ -21,3 +21,24 @@ My goal is to learn TypeScript, and NestJS along with Supabase. So..
 - TypeScript
 - NestJS
 - Supabase
+- AWS App Runner
+
+### Supabase Migrations
+
+Link the CLI to your Supabase project (one-time):
+
+```bash
+pnpx supabase link --project-ref <your-project-ref>
+```
+
+Apply pending migrations to the remote database:
+
+```bash
+pnpx supabase db push
+```
+
+Reset the remote database (destructive — drops all tables, re-runs migrations + seed):
+
+```bash
+pnpx supabase db reset --linked
+```

--- a/apprunner.yaml
+++ b/apprunner.yaml
@@ -1,4 +1,7 @@
 version: 1.0
+### If you're using AWS App Runner, you will need to do manual
+# Configuration, because you don't want the SUPABASE_URL and SUPABASE_ANON_KEY to be exposed.
+# In the github repo.
 runtime: nodejs22
 build:
   commands:


### PR DESCRIPTION
Add warning about App Runner env var configuration in apprunner.yaml
to prevent accidental exposure of Supabase credentials. Document
migration commands in README for database schema management. Update
CLAUDE.md to clarify manual App Runner config requirement and note
CI workflow. Add production URL and App Runner gotcha for better
deployment guidance.