### PR TITLE
✨ feat: Make link title optional in create DTO

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkblog",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "My personal linkblog",
   "author": "Vid Luther (vid@luther.io)",
   "private": true,

--- a/src/links/dto/create-link.dto.ts
+++ b/src/links/dto/create-link.dto.ts
@@ -4,8 +4,9 @@ export class CreateLinkDto {
   @IsUrl()
   url!: string;
 
+  @IsOptional()
   @IsString()
-  title!: string;
+  title?: string;
 
   @IsOptional()
   @IsString()


### PR DESCRIPTION
Allow links to be created without requiring a title field. This
provides more flexibility when saving links where the title can be
extracted later or is not immediately available.

Also bump version from 0.0.1 to 0.0.2 to reflect this API change.