### PR TITLE
🔧 Configure post-tool hooks for code formatting and linting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,5 +14,22 @@
       "Bash(pnpm ls:*)"
     ]
   },
-  "prefersReducedMotion": true
+  "prefersReducedMotion": true,
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pnpx oxfmt ."
+          },
+          {
+            "type": "command",
+            "command": "pnpx oxlint ."
+          }
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
Add post-tool hooks to automatically run oxfmt and oxlint
after edit or write operations to ensure code quality and
consistency.