### PR TITLE
feat: redesign ApiKeyGuard for DB-backed multi-tenant auth (#60)

### DIFF
--- a/src/auth/api-key.guard.spec.ts
+++ b/src/auth/api-key.guard.spec.ts
@@ -1,93 +1,233 @@
-import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import {
+  ExecutionContext,
+  ForbiddenException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { ConfigService } from '@nestjs/config';
-import { ApiKeyGuard } from './api-key.guard';
+import { createHash } from 'crypto';
+import { SUPABASE_CLIENT } from '../supabase/supabase.module.js';
+import { ApiKeyGuard } from './api-key.guard.js';
 
 describe('ApiKeyGuard', () => {
   let guard: ApiKeyGuard;
   let reflector: Reflector;
-  let configService: ConfigService;
+  let supabase: Record<string, unknown>;
 
-  const API_KEY = 'test-api-key-123';
+  const RAW_KEY = 'lb_' + 'a'.repeat(64);
+  const KEY_HASH = createHash('sha256').update(RAW_KEY).digest('hex');
+  const USER_ID = 'user-uuid-1';
+  const USERNAME = 'alice';
+
+  function buildSupabaseMock(opts: {
+    apiKeyRow?: Record<string, unknown> | null;
+    apiKeyError?: Record<string, unknown> | null;
+    profileRow?: Record<string, unknown> | null;
+    profileError?: Record<string, unknown> | null;
+  }) {
+    const {
+      apiKeyRow = { user_id: USER_ID },
+      apiKeyError = null,
+      profileRow = { username: USERNAME },
+      profileError = null,
+    } = opts;
+
+    // Each .from() call returns a chainable builder
+    const apiKeyBuilder = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi
+        .fn()
+        .mockResolvedValue({ data: apiKeyRow, error: apiKeyError }),
+      update: vi.fn().mockReturnThis(),
+    };
+
+    const profileBuilder = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi
+        .fn()
+        .mockResolvedValue({ data: profileRow, error: profileError }),
+    };
+
+    // update chain for last_used_at (fire-and-forget)
+    const updateBuilder = {
+      eq: vi.fn().mockReturnThis(),
+      // resolves silently
+      then: vi.fn(),
+    };
+
+    const fromMock = vi.fn((table: string) => {
+      if (table === 'api_keys')
+        return { ...apiKeyBuilder, update: vi.fn(() => updateBuilder) };
+      if (table === 'profiles') return profileBuilder;
+      return {};
+    });
+
+    return { from: fromMock };
+  }
 
   function createMockContext(
-    headers: Record<string, string> = {},
+    opts: {
+      headers?: Record<string, string>;
+      params?: Record<string, string>;
+      isPublic?: boolean;
+    } = {},
   ): ExecutionContext {
+    const { headers = {}, params = {}, isPublic = false } = opts;
+    const req = { headers, params, user: undefined as unknown };
     return {
       getHandler: vi.fn(),
       getClass: vi.fn(),
       switchToHttp: () => ({
-        getRequest: () => ({ headers }),
+        getRequest: () => req,
       }),
+      _req: req,
+      _isPublic: isPublic,
     } as unknown as ExecutionContext;
   }
 
   beforeEach(() => {
     reflector = new Reflector();
-    configService = {
-      get: vi.fn().mockReturnValue(API_KEY),
-    } as unknown as ConfigService;
-    guard = new ApiKeyGuard(reflector, configService);
+    supabase = buildSupabaseMock({});
+    guard = new ApiKeyGuard(reflector, supabase as never);
   });
 
   it('should be defined', () => {
     expect(guard).toBeDefined();
   });
 
-  it('should allow access when route is marked @Public()', () => {
+  it('should allow access for @Public() routes without querying DB', async () => {
     vi.spyOn(reflector, 'getAllAndOverride').mockReturnValue(true);
-    const context = createMockContext();
+    const ctx = createMockContext({ isPublic: true });
 
-    expect(guard.canActivate(context)).toBe(true);
+    const result = await guard.canActivate(ctx);
+
+    expect(result).toBe(true);
+    expect(
+      (supabase as { from: ReturnType<typeof vi.fn> }).from,
+    ).not.toHaveBeenCalled();
   });
 
-  it('should allow access with valid API key', () => {
+  it('should throw 401 when x-api-key header is missing', async () => {
     vi.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
-    const context = createMockContext({ 'x-api-key': API_KEY });
+    const ctx = createMockContext({ headers: {} });
 
-    expect(guard.canActivate(context)).toBe(true);
-  });
-
-  it('should throw UnauthorizedException when x-api-key header is missing', () => {
-    vi.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
-    const context = createMockContext();
-
-    expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
-    expect(() => guard.canActivate(context)).toThrow(
+    await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
+    await expect(guard.canActivate(ctx)).rejects.toThrow(
       'Missing x-api-key header',
     );
   });
 
-  it('should throw UnauthorizedException when API key is wrong', () => {
+  it('should throw 401 when key hash is not found in api_keys table', async () => {
     vi.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
-    const context = createMockContext({ 'x-api-key': 'wrong-key' });
+    supabase = buildSupabaseMock({
+      apiKeyRow: null,
+      apiKeyError: { code: 'PGRST116', message: 'no rows' },
+    });
+    guard = new ApiKeyGuard(reflector, supabase as never);
+    const ctx = createMockContext({ headers: { 'x-api-key': RAW_KEY } });
 
-    expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
-    expect(() => guard.canActivate(context)).toThrow('Invalid API key');
+    await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
+    await expect(guard.canActivate(ctx)).rejects.toThrow('Invalid API key');
   });
 
-  it('should throw UnauthorizedException when API_KEY env var is not configured', () => {
+  it('should throw 401 on unexpected DB error when looking up key', async () => {
     vi.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
-    (configService.get as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
-    const context = createMockContext({ 'x-api-key': 'some-key' });
+    supabase = buildSupabaseMock({
+      apiKeyRow: null,
+      apiKeyError: { code: '500', message: 'DB exploded' },
+    });
+    guard = new ApiKeyGuard(reflector, supabase as never);
+    const ctx = createMockContext({ headers: { 'x-api-key': RAW_KEY } });
 
-    expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
-    expect(() => guard.canActivate(context)).toThrow('API_KEY not configured');
+    await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
   });
 
-  it('should reject keys of different lengths', () => {
+  it('should throw 403 when username param does not match key owner', async () => {
     vi.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
-    const context = createMockContext({ 'x-api-key': 'short' });
+    const ctx = createMockContext({
+      headers: { 'x-api-key': RAW_KEY },
+      params: { username: 'bob' }, // key belongs to 'alice'
+    });
 
-    expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+    await expect(guard.canActivate(ctx)).rejects.toThrow(ForbiddenException);
+    await expect(guard.canActivate(ctx)).rejects.toThrow(
+      'API key does not match the requested user',
+    );
   });
 
-  it('should not check API key for public routes', () => {
-    vi.spyOn(reflector, 'getAllAndOverride').mockReturnValue(true);
-    // No x-api-key header, but route is public — should still pass
-    const context = createMockContext();
+  it('should attach request.user and return true for valid key with matching username', async () => {
+    vi.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+    const ctx = createMockContext({
+      headers: { 'x-api-key': RAW_KEY },
+      params: { username: USERNAME },
+    });
+    const req = ctx.switchToHttp().getRequest();
 
-    expect(guard.canActivate(context)).toBe(true);
-    expect(configService.get).not.toHaveBeenCalled();
+    const result = await guard.canActivate(ctx);
+
+    expect(result).toBe(true);
+    expect(req.user).toEqual({ userId: USER_ID, username: USERNAME });
+  });
+
+  it('should attach request.user and return true when no username param (non-user-scoped route)', async () => {
+    vi.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+    const ctx = createMockContext({
+      headers: { 'x-api-key': RAW_KEY },
+      params: {},
+    });
+    const req = ctx.switchToHttp().getRequest();
+
+    const result = await guard.canActivate(ctx);
+
+    expect(result).toBe(true);
+    expect(req.user).toEqual({ userId: USER_ID, username: USERNAME });
+  });
+
+  it('should update last_used_at asynchronously (fire-and-forget)', async () => {
+    vi.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+
+    // Rebuild mock so we can check the update call
+    const updateEqMock = vi.fn().mockReturnThis();
+    const updateMock = vi.fn(() => ({ eq: updateEqMock }));
+
+    const singleApiKeyMock = vi.fn().mockResolvedValue({
+      data: { user_id: USER_ID },
+      error: null,
+    });
+    const singleProfileMock = vi.fn().mockResolvedValue({
+      data: { username: USERNAME },
+      error: null,
+    });
+
+    const fromMock = vi.fn((table: string) => {
+      if (table === 'api_keys') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          single: singleApiKeyMock,
+          update: updateMock,
+        };
+      }
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: singleProfileMock,
+      };
+    });
+
+    guard = new ApiKeyGuard(reflector, { from: fromMock } as never);
+
+    const ctx = createMockContext({
+      headers: { 'x-api-key': RAW_KEY },
+      params: { username: USERNAME },
+    });
+
+    await guard.canActivate(ctx);
+
+    expect(updateMock).toHaveBeenCalledWith({
+      last_used_at: expect.any(String),
+    });
+    expect(updateEqMock).toHaveBeenCalledWith('key_hash', KEY_HASH);
   });
 });

--- a/src/auth/api-key.guard.ts
+++ b/src/auth/api-key.guard.ts
@@ -1,22 +1,25 @@
 import {
   CanActivate,
   ExecutionContext,
+  ForbiddenException,
+  Inject,
   Injectable,
   UnauthorizedException,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { ConfigService } from '@nestjs/config';
-import { timingSafeEqual } from 'crypto';
-import { IS_PUBLIC_KEY } from './public.decorator';
+import { SupabaseClient } from '@supabase/supabase-js';
+import { createHash } from 'crypto';
+import { SUPABASE_CLIENT } from '../supabase/supabase.module.js';
+import { IS_PUBLIC_KEY } from './public.decorator.js';
 
 @Injectable()
 export class ApiKeyGuard implements CanActivate {
   constructor(
     private readonly reflector: Reflector,
-    private readonly configService: ConfigService,
+    @Inject(SUPABASE_CLIENT) private readonly supabase: SupabaseClient,
   ) {}
 
-  canActivate(context: ExecutionContext): boolean {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
     const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
       context.getHandler(),
       context.getClass(),
@@ -33,27 +36,49 @@ export class ApiKeyGuard implements CanActivate {
       throw new UnauthorizedException('Missing x-api-key header');
     }
 
-    const expectedKey = this.configService.get<string>('API_KEY');
+    const keyHash = createHash('sha256').update(apiKey).digest('hex');
 
-    if (!expectedKey) {
-      throw new UnauthorizedException('API_KEY not configured');
-    }
+    // Look up key by hash in the api_keys table
+    const { data: apiKeyRow, error: apiKeyError } = await this.supabase
+      .from('api_keys')
+      .select('user_id')
+      .eq('key_hash', keyHash)
+      .single();
 
-    if (!this.keysMatch(apiKey, expectedKey)) {
+    if (apiKeyError || !apiKeyRow) {
       throw new UnauthorizedException('Invalid API key');
     }
 
-    return true;
-  }
+    const userId: string = apiKeyRow.user_id;
 
-  private keysMatch(a: string, b: string): boolean {
-    const bufA = Buffer.from(a);
-    const bufB = Buffer.from(b);
+    // Resolve the username for this user
+    const { data: profileRow, error: profileError } = await this.supabase
+      .from('profiles')
+      .select('username')
+      .eq('id', userId)
+      .single();
 
-    if (bufA.length !== bufB.length) {
-      return false;
+    if (profileError || !profileRow) {
+      throw new UnauthorizedException('Invalid API key');
     }
 
-    return timingSafeEqual(bufA, bufB);
+    const username: string = profileRow.username;
+
+    // If there is a :username param in the URL, verify the key owner matches
+    const usernameParam: string | undefined = request.params?.username;
+    if (usernameParam && usernameParam !== username) {
+      throw new ForbiddenException('API key does not match the requested user');
+    }
+
+    // Attach user to the request
+    request.user = { userId, username };
+
+    // Fire-and-forget: update last_used_at asynchronously
+    void this.supabase
+      .from('api_keys')
+      .update({ last_used_at: new Date().toISOString() })
+      .eq('key_hash', keyHash);
+
+    return true;
   }
 }


### PR DESCRIPTION
## Summary

- Rewrites `ApiKeyGuard` to be `async`, replacing the single `API_KEY` env-var check with a two-step Supabase lookup: SHA-256 hash → `api_keys` table → `profiles` table
- Enforces username-scoped ownership: returns `403 ForbiddenException` when `request.params.username` doesn't match the key owner
- Attaches `request.user = { userId, username }` on success for downstream use by `@CurrentUser()`
- Updates `last_used_at` asynchronously (fire-and-forget, does not block the request)
- Removes `ConfigService` dependency entirely

## Tests

All 9 guard tests pass (was 7 old tests, now 9 new covering: public bypass, missing header, key not found, DB error, username mismatch, matching username, no username param, fire-and-forget update).

47/47 total tests passing.

Closes #60
Part of Epic: #53

> **Stacked on**: #67 (Phase 2 backend foundation)