### PR TITLE
docs: remove unused site config and dead linkRemove a commented-out remote_theme and minimal_mistakes skin settingsand delete the unused defaults/breadcrumbs override from _config.yml tosimplify configuration. Also remove the obsolete "Implementation Plan"

### DIFF
--- a/github_pages/_config.yml
+++ b/github_pages/_config.yml
@@ -1,6 +1,3 @@
-# remote_theme: "mmistakes/minimal-mistakes"
-# minimal_mistakes_skin: "air"
-
 title: Linkblog
 subtitle: 'API Documentation'
 description: A personal bookmarking API that publishes an RSS feed
@@ -14,9 +11,3 @@ plugins:
   - jekyll-include-cache
 
 breadcrumbs: true
-
-defaults:
-  - scope:
-      path: ''
-    values:
-      layout: 'single'

--- a/github_pages/index.md
+++ b/github_pages/index.md
@@ -22,7 +22,6 @@ A personal bookmarking API built with **NestJS**, **TypeScript**, and **Supabase
 - [Browser Extension](browser-extension) -- Chrome/Safari extension docs
 - [Edge Functions](edge-functions) -- Supabase Edge Function docs
 - [API Docs (Swagger)](https://api.linkblog.in/api-docs) -- Interactive API documentation
-- [Implementation Plan](implementation-plan) -- Roadmap and issue tracker
 
 ## Tech Stack
 


### PR DESCRIPTION
link from the navigation in github_pages/index.md to avoid a brokenor redundant roadmap entry.

These changes clean up unused/commented config and fix navigation toreflect current documentation structure.