### PR TITLE
chore(docs): add site structure, permalinks, and theme defaultsUpdate Jekyll docs site configuration and content to improve navigation,

### DIFF
--- a/github_pages/_config.yml
+++ b/github_pages/_config.yml
@@ -1,8 +1,11 @@
 title: Linkblog
 subtitle: 'API Documentation'
 description: A personal bookmarking API that publishes an RSS feed
-url: https://www.linkblog.in
+url: https://docs.linkblog.in
 baseurl: ''
+
+remote_theme: mmistakes/minimal-mistakes
+minimal_mistakes_skin: 'air'
 
 markdown: kramdown
 highlighter: rouge
@@ -11,3 +14,13 @@ plugins:
   - jekyll-include-cache
 
 breadcrumbs: true
+
+defaults:
+  - scope:
+      path: ''
+    values:
+      layout: single
+      sidebar:
+        nav: 'docs'
+      toc: true
+      toc_sticky: true

--- a/github_pages/_data/navigation.yml
+++ b/github_pages/_data/navigation.yml
@@ -15,3 +15,27 @@ main:
     url: /edge-functions
   - title: 'API Docs'
     url: https://api.linkblog.in/api-docs
+
+docs:
+  - title: 'Getting Started'
+    children:
+      - title: 'Setup'
+        url: /getting-started
+  - title: 'API'
+    children:
+      - title: 'API Reference'
+        url: /api
+  - title: 'Architecture'
+    children:
+      - title: 'Overview'
+        url: /architecture
+      - title: 'Edge Functions'
+        url: /edge-functions
+  - title: 'Operations'
+    children:
+      - title: 'Deployment'
+        url: /deployment
+  - title: 'Extensions'
+    children:
+      - title: 'Browser Extension'
+        url: /browser-extension

--- a/github_pages/api.md
+++ b/github_pages/api.md
@@ -1,6 +1,7 @@
 ---
 layout: single
 title: API Reference
+permalink: /api/
 toc: true
 ---
 

--- a/github_pages/architecture.md
+++ b/github_pages/architecture.md
@@ -1,6 +1,7 @@
 ---
 layout: single
 title: Architecture
+permalink: /architecture/
 toc: true
 ---
 

--- a/github_pages/browser-extension.md
+++ b/github_pages/browser-extension.md
@@ -1,6 +1,7 @@
 ---
 layout: single
 title: Browser Extension
+permalink: /browser-extension/
 toc: true
 ---
 

--- a/github_pages/deployment.md
+++ b/github_pages/deployment.md
@@ -1,6 +1,7 @@
 ---
 layout: single
 title: Deployment
+permalink: /deployment/
 toc: true
 ---
 

--- a/github_pages/edge-functions.md
+++ b/github_pages/edge-functions.md
@@ -1,6 +1,7 @@
 ---
 layout: single
 title: Edge Functions
+permalink: /edge-functions/
 toc: true
 ---
 

--- a/github_pages/getting-started.md
+++ b/github_pages/getting-started.md
@@ -1,6 +1,7 @@
 ---
 layout: single
 title: Getting Started
+permalink: /getting-started/
 toc: true
 ---
 

--- a/github_pages/index.md
+++ b/github_pages/index.md
@@ -1,6 +1,8 @@
 ---
 layout: home
 title: Linkblog
+permalink: /
+toc: false
 ---
 
 A personal bookmarking API built with **NestJS**, **TypeScript**, and **Supabase**. It stores articles with notes and publishes them as a public **RSS 2.0 feed** for the blogroll at [luther.io/blogroll](https://luther.io/blogroll).


### PR DESCRIPTION
permalinks, and theme settings.

- Set permalink front-matter for all doc pages (api, edge-functions,
 getting-started, browser-extension, deployment, architecture, index)
 to provide clean URLs and consistent trailing slashes.
- Change site URL to docs.linkblog.in and add remote_theme (mmistakes/minimal-mistakes) with skin 'air' and Rouge highlighter.
- Add global defaults for layout, sidebar nav, table-of-contents and sticky TOC to reduce repetition in page front-matter.
- Extend navigation data with a docs section and structured child pages (Getting Started, API, Architecture, Operations, Extensions).
- Add permalink /api/ for API reference page and set index permalink to root with toc disabled for the home layout.

These changes tidy the documentation site structure, enable a consistenttheme and navigation, and simplify per-page front-matter maintenance.