### PR TITLE
feat-db-rename-username-to-handle

### DIFF
--- a/.opencode/plans/87-rename-username-to-handle.md
+++ b/.opencode/plans/87-rename-username-to-handle.md
@@ -1,0 +1,60 @@
+# Plan: Rename `username` to `handle` across codebase
+
+**Issue:** #87
+
+The migration `20260304141015_rename_username_to_handle_add_trigger_and_rls_policies.sql` renamed `profiles.username` to `profiles.handle`. This plan updates the rest of the codebase (code, tests, docs, Postman) to match.
+
+## Tasks
+
+### Source Code — Interfaces & Types
+
+- [ ] `src/users/users.service.ts` — `UserProfile.username` → `.handle`
+- [ ] `src/auth/current-user.decorator.ts` — `CurrentUserPayload.username` → `.handle`
+- [ ] `src/links/links.controller.ts` — `AuthUser.username` → `.handle`
+- [ ] `src/api-keys/api-keys.controller.ts` — `AuthUser.username` → `.handle`
+
+### Source Code — Services & Guards
+
+- [ ] `src/users/users.service.ts` — `findByUsername()` → `findByHandle()`, Supabase `.select("id, handle")`, `.eq("handle", ...)`
+- [ ] `src/auth/api-key.guard.ts` — `.select("handle")`, `profileRow.handle`, route param `:handle`, `request.user = { userId, handle }`
+- [ ] `src/feed/feed.service.ts` — rename `username` parameter to `handle`
+
+### Source Code — Controllers
+
+- [ ] `src/links/links.controller.ts` — `@Controller(":handle/links")`, `@ApiParam({ name: "handle" })`, `@Param("handle")`
+- [ ] `src/feed/feed.controller.ts` — same pattern
+- [ ] `src/api-keys/api-keys.controller.ts` — same pattern
+
+### Tests
+
+- [ ] `src/users/users.service.spec.ts`
+- [ ] `src/auth/current-user.decorator.spec.ts`
+- [ ] `src/auth/api-key.guard.spec.ts`
+- [ ] `src/links/links.controller.spec.ts`
+- [ ] `src/feed/feed.service.spec.ts`
+- [ ] `src/feed/feed.controller.spec.ts`
+
+### Browser Extension
+
+- [ ] `browser-extension/src/types/index.ts` — placeholder `{your-username}` → `{your-handle}`
+
+### Documentation
+
+- [ ] `CLAUDE.md`
+- [ ] `github_pages/api.md`
+- [ ] `github_pages/architecture.md`
+- [ ] `github_pages/getting-started.md`
+- [ ] `github_pages/browser-extension.md`
+- [ ] `github_pages/edge-functions.md`
+
+### Postman
+
+- [ ] `postman/Linkblog API.postman_collection.json` — `{{username}}` → `{{handle}}`
+
+### Not Changed
+
+- Applied migrations (`20260225000001`, `20260225000002`) — leave as-is
+
+### Verification
+
+- [ ] `pnpm lint && pnpm fmt && pnpm test` all pass

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,9 @@ Linkblog Service - This the API for Linkblog, a linkblog service.
 
 ## Key Conventions
 
-- **Endpoints:** `/:username/links` (CRUD; reads public, writes protected), `/:username/feed` (public RSS 2.0), `/:username/api-keys` (key management, protected), `/health` (public), `/api-docs` (Swagger UI)
+- **Endpoints:** `/:handle/links` (CRUD; reads public, writes protected), `/:handle/feed` (public RSS 2.0), `/:handle/api-keys` (key management, protected), `/health` (public), `/api-docs` (Swagger UI)
 - **Auth:** Multi-user, global `ApiKeyGuard` via `APP_GUARD`. Write endpoints require `x-api-key` header (per-user keys stored as SHA-256 hashes in `api_keys` table). Public routes use `@Public()` decorator to opt out. See `src/auth/`.
-- **Data model:** Supabase tables: `links` (id, url, title, summary, user_id, created_at, updated_at), `profiles` (id, username), `api_keys` (id, user_id, name, key_hash, created_at, last_used_at), `app_config` (key, value)
+- **Data model:** Supabase tables: `links` (id, url, title, summary, user_id, created_at, updated_at), `profiles` (id, handle), `api_keys` (id, user_id, name, key_hash, created_at, last_used_at), `app_config` (key, value)
 - **Deploy:** AWS App Runner (manual console config; `apprunner.yaml` is reference only). Production URL: `api.linkblog.in`
 
 ## Commands
@@ -42,7 +42,7 @@ AppModule
 ├── LoggerModule       (global, nestjs-pino structured logging)
 ├── SupabaseModule     (global, provides SUPABASE_CLIENT token)
 ├── AuthModule         (global ApiKeyGuard via APP_GUARD)
-├── UsersModule        (username → user_id lookups)
+├── UsersModule        (handle → user_id lookups)
 ├── ApiKeysModule      (per-user API key CRUD)
 ├── LinksModule        (CRUD service + controller)
 ├── FeedModule         (RSS feed generation)

--- a/browser-extension/src/types/index.ts
+++ b/browser-extension/src/types/index.ts
@@ -31,9 +31,9 @@ export interface ExtensionSettings {
   apiEndpoint: string;
 }
 
-// Default endpoint placeholder — users must replace {your-username} with their actual username.
-// Format: https://api.linkblog.in/{your-username}/links
+// Default endpoint placeholder — users must replace {your-handle} with their actual handle.
+// Format: https://api.linkblog.in/{your-handle}/links
 export const DEFAULT_SETTINGS: ExtensionSettings = {
   apiKey: "",
-  apiEndpoint: "https://api.linkblog.in/{your-username}/links",
+  apiEndpoint: "https://api.linkblog.in/{your-handle}/links",
 };

--- a/github_pages/api.md
+++ b/github_pages/api.md
@@ -13,7 +13,7 @@ Base URL: `http://localhost:3000` (local) or `https://api.linkblog.in` (producti
 
 ## Authentication
 
-Linkblog uses **per-user API keys** to protect write endpoints. Each user can create multiple named API keys via the [`/:username/api-keys`](#api-key-management) endpoints.
+Linkblog uses **per-user API keys** to protect write endpoints. Each user can create multiple named API keys via the [`/:handle/api-keys`](#api-key-management) endpoints.
 
 Keys are passed as a request header:
 
@@ -25,10 +25,10 @@ When a request arrives:
 
 1. The API hashes the key with SHA-256
 2. Looks up the hash in the `api_keys` table to find the owning `user_id`
-3. Resolves the user's `username` from the `profiles` table
-4. If the URL contains a `:username` param, verifies the key owner matches — returns `403 Forbidden` if they don't
+3. Resolves the user's `handle` from the `profiles` table
+4. If the URL contains a `:handle` param, verifies the key owner matches — returns `403 Forbidden` if they don't
 
-Read endpoints (`GET /:username/links`, `GET /:username/links/:id`), the RSS feed (`GET /:username/feed`), and the health check (`GET /health`) are **public** — no API key required.
+Read endpoints (`GET /:handle/links`, `GET /:handle/links/:id`), the RSS feed (`GET /:handle/feed`), and the health check (`GET /health`) are **public** — no API key required.
 
 ---
 
@@ -52,7 +52,7 @@ curl http://localhost:3000/health
 
 ---
 
-### `POST /:username/links`
+### `POST /:handle/links`
 
 Create a new link.
 
@@ -101,7 +101,7 @@ curl -X POST http://localhost:3000/alice/links \
 
 ---
 
-### `GET /:username/links`
+### `GET /:handle/links`
 
 List all links for a user, sorted by newest first.
 
@@ -138,7 +138,7 @@ curl http://localhost:3000/alice/links
 
 ---
 
-### `GET /:username/links/:id`
+### `GET /:handle/links/:id`
 
 Get a single link by ID.
 
@@ -166,7 +166,7 @@ curl http://localhost:3000/alice/links/1
 
 ---
 
-### `PATCH /:username/links/:id`
+### `PATCH /:handle/links/:id`
 
 Update an existing link.
 
@@ -202,7 +202,7 @@ curl -X PATCH http://localhost:3000/alice/links/1 \
 
 ---
 
-### `DELETE /:username/links/:id`
+### `DELETE /:handle/links/:id`
 
 Delete a link.
 
@@ -219,7 +219,7 @@ curl -X DELETE http://localhost:3000/alice/links/1 \
 
 ---
 
-### `GET /:username/feed`
+### `GET /:handle/feed`
 
 Public RSS 2.0 feed of all links for a user, newest first.
 
@@ -253,7 +253,7 @@ curl http://localhost:3000/alice/feed
 
 ## API Key Management
 
-### `GET /:username/api-keys`
+### `GET /:handle/api-keys`
 
 List all API keys for the authenticated user. Returns metadata only (never the raw key).
 
@@ -279,7 +279,7 @@ curl http://localhost:3000/alice/api-keys \
 
 ---
 
-### `POST /:username/api-keys`
+### `POST /:handle/api-keys`
 
 Create a new API key. The raw key is returned **only once** in the response — store it securely.
 
@@ -320,7 +320,7 @@ curl -X POST http://localhost:3000/alice/api-keys \
 
 ---
 
-### `DELETE /:username/api-keys/:id`
+### `DELETE /:handle/api-keys/:id`
 
 Delete an API key by ID.
 
@@ -374,10 +374,10 @@ All errors follow a consistent format:
 
 ### `profiles` table
 
-| Column     | Type      | Description                       |
-| ---------- | --------- | --------------------------------- |
-| `id`       | uuid (PK) | User ID (matches Supabase auth)   |
-| `username` | text      | Unique username used in URL paths |
+| Column   | Type      | Description                     |
+| -------- | --------- | ------------------------------- |
+| `id`     | uuid (PK) | User ID (matches Supabase auth) |
+| `handle` | text      | Unique handle used in URL paths |
 
 ### `api_keys` table
 

--- a/github_pages/architecture.md
+++ b/github_pages/architecture.md
@@ -26,9 +26,9 @@ Linkblog is a multi-user bookmarking API. There is no frontend — it is designe
 ┌──────────────────┐      ┌───────────────┴──────────────┐
 │  curl / apps /   │─────▶│         NestJS API            │
 │  browser ext.    │ HTTP  │                               │
-└──────────────────┘      │  /:username/links  (CRUD)     │
-                          │  /:username/feed   (RSS)      │
-                          │  /:username/api-keys (mgmt)   │
+└──────────────────┘      │  /:handle/links    (CRUD)     │
+                          │  /:handle/feed     (RSS)      │
+                          │  /:handle/api-keys (mgmt)     │
                           │  /health           (public)   │
                           │  /docs             (Swagger)  │
                           └───────────────────────────────┘
@@ -53,7 +53,7 @@ AppModule
 ├── LoggerModule          (global, nestjs-pino structured logging)
 ├── SupabaseModule        (global, provides Supabase client)
 ├── AuthModule            (global ApiKeyGuard via APP_GUARD)
-├── UsersModule           (username → user_id lookups)
+├── UsersModule           (handle → user_id lookups)
 ├── ApiKeysModule         (per-user API key CRUD)
 ├── LinksModule           (link CRUD service + controller)
 ├── FeedModule            (per-user RSS feed generation)
@@ -85,12 +85,12 @@ Registers the `ApiKeyGuard` as a global `APP_GUARD`. All routes are protected by
 1. Extracts the `x-api-key` header
 2. Hashes it with SHA-256
 3. Looks up the hash in the `api_keys` table
-4. Resolves the user's profile and attaches `{ userId, username }` to the request
-5. Verifies the `:username` URL param matches the key owner (403 if not)
+4. Resolves the user's profile and attaches `{ userId, handle }` to the request
+5. Verifies the `:handle` URL param matches the key owner (403 if not)
 
 ### UsersModule
 
-Provides `UsersService.findByUsername(username)` to resolve a username to a user ID. Used by `LinksController` and `FeedController` for public (unauthenticated) routes that need to scope data by user.
+Provides `UsersService.findByHandle(handle)` to resolve a handle to a user ID. Used by `LinksController` and `FeedController` for public (unauthenticated) routes that need to scope data by user.
 
 ### ApiKeysModule
 
@@ -98,11 +98,11 @@ CRUD for per-user API keys. Raw keys are generated as `lb_` + 32 random bytes (h
 
 ### LinksModule
 
-The core feature module. `LinksService` handles CRUD operations scoped by `user_id`. `LinksController` maps HTTP verbs to service methods at `/:username/links`.
+The core feature module. `LinksService` handles CRUD operations scoped by `user_id`. `LinksController` maps HTTP verbs to service methods at `/:handle/links`.
 
 ### FeedModule
 
-`FeedService` generates RSS 2.0 XML per user using the `feed` npm package. The feed title is `{username}'s Linkblog`. `FeedController` serves it at `GET /:username/feed` with `Content-Type: application/rss+xml`.
+`FeedService` generates RSS 2.0 XML per user using the `feed` npm package. The feed title is `{handle}'s Linkblog`. `FeedController` serves it at `GET /:handle/feed` with `Content-Type: application/rss+xml`.
 
 ### HealthModule
 
@@ -112,7 +112,7 @@ Simple `GET /health` returning `{ status: "ok" }`. Used by App Runner for health
 
 ### Multi-user with per-user API keys
 
-Each user has a `profiles` row and can create multiple named API keys. Keys are SHA-256 hashed before storage — the raw key is never persisted. URL paths are scoped by `:username` so each user's data is isolated.
+Each user has a `profiles` row and can create multiple named API keys. Keys are SHA-256 hashed before storage — the raw key is never persisted. URL paths are scoped by `:handle` so each user's data is isolated.
 
 ### Supabase as the data layer
 
@@ -137,21 +137,21 @@ The API is meant to be called from the [browser extension](browser-extension), s
 
 ## Request Flow (Protected Endpoints)
 
-1. Client sends HTTP request with `x-api-key` header to `/:username/links`
+1. Client sends HTTP request with `x-api-key` header to `/:handle/links`
 2. `ApiKeyGuard` extracts and SHA-256 hashes the API key
 3. Guard looks up `key_hash` in `api_keys` table → gets `user_id`
-4. Guard looks up `user_id` in `profiles` table → gets `username`
-5. Guard verifies URL `:username` param matches the key owner (403 if mismatch)
-6. Guard attaches `{ userId, username }` to `request.user`
+4. Guard looks up `user_id` in `profiles` table → gets `handle`
+5. Guard verifies URL `:handle` param matches the key owner (403 if mismatch)
+6. Guard attaches `{ userId, handle }` to `request.user`
 7. Controller delegates to service with the authenticated user's ID
 8. Service calls Supabase, checks `{ data, error }`, throws NestJS exceptions on failure
 9. Controller returns the response
 
 ## Request Flow (Public Endpoints)
 
-1. Client sends HTTP request to `/:username/links` (GET)
+1. Client sends HTTP request to `/:handle/links` (GET)
 2. `ApiKeyGuard` sees `@Public()` decorator → skips auth
-3. Controller calls `UsersService.findByUsername(username)` → gets user ID
+3. Controller calls `UsersService.findByHandle(handle)` → gets user ID
 4. Controller delegates to service with the resolved user ID
 5. Service returns scoped data
 
@@ -178,12 +178,12 @@ linkblog/
 │   ├── app.service.ts         # App-level service
 │   ├── auth/
 │   │   ├── auth.module.ts     # Registers global APP_GUARD
-│   │   ├── api-key.guard.ts   # SHA-256 key lookup + username verification
+│   │   ├── api-key.guard.ts   # SHA-256 key lookup + handle verification
 │   │   ├── public.decorator.ts    # @Public() to opt out of auth
 │   │   └── current-user.decorator.ts  # @CurrentUser() param decorator
 │   ├── users/
 │   │   ├── users.module.ts
-│   │   └── users.service.ts   # findByUsername()
+│   │   └── users.service.ts   # findByHandle()
 │   ├── api-keys/
 │   │   ├── api-keys.module.ts
 │   │   ├── api-keys.service.ts    # Key generation, hashing, CRUD

--- a/github_pages/browser-extension.md
+++ b/github_pages/browser-extension.md
@@ -49,7 +49,7 @@ pnpm clean:extension && pnpm build:extension
 Click the Linkblog extension icon to open the popup. Scroll to the **Settings** section:
 
 1. **API Key** — enter your `x-api-key` value (the raw key starting with `lb_`)
-2. **API Endpoint** — set to your links endpoint, e.g. `https://api.linkblog.in/alice/links` (replace `alice` with your username)
+2. **API Endpoint** — set to your links endpoint, e.g. `https://api.linkblog.in/alice/links` (replace `alice` with your handle)
 3. Click **Save Settings**
 
 Settings are stored in `browser.storage.sync` and persist across browser sessions.

--- a/github_pages/edge-functions.md
+++ b/github_pages/edge-functions.md
@@ -29,7 +29,7 @@ CREATE TRIGGER on_link_insert_fetch_metadata
 
 The `notify_fetch_metadata()` function uses `pg_net` to make a fire-and-forget HTTP POST to the edge function with `?link_id={id}`.
 
-This means when you `POST /:username/links` with just a URL (no title), the metadata is fetched and populated automatically within a few seconds.
+This means when you `POST /:handle/links` with just a URL (no title), the metadata is fetched and populated automatically within a few seconds.
 
 ## Query Parameters
 

--- a/github_pages/getting-started.md
+++ b/github_pages/getting-started.md
@@ -62,7 +62,7 @@ This runs `supabase/seed.sql` which inserts example data and configures the `app
 Before testing write endpoints, you need a user profile and API key. Insert a profile manually in the Supabase dashboard or via SQL:
 
 ```sql
-INSERT INTO profiles (id, username) VALUES ('your-auth-user-id', 'alice');
+INSERT INTO profiles (id, handle) VALUES ('your-auth-user-id', 'alice');
 ```
 
 Then create an API key via the API once the server is running (you'll need to insert an initial key hash manually, or use the Supabase dashboard to bootstrap).

--- a/postman/Linkblog API.postman_collection.json
+++ b/postman/Linkblog API.postman_collection.json
@@ -2,7 +2,7 @@
   "info": {
     "_postman_id": "2558c2dc-6226-48e8-bffb-4172f4d23bb3",
     "name": "Linkblog API",
-    "description": "Personal bookmarking API (NestJS + Supabase) that publishes an RSS feed.\n\n## Setup\n1. Import the **Linkblog - Local** environment\n2. Set the `userApiKey` variable to your API key value (format: `lb_<64 hex chars>`)\n3. Set the `username` variable to your profile username\n4. Start the server: `pnpm start:dev`\n5. Run requests — the collection auto-captures `linkId` from create/list responses\n\n## Auth\nAll write endpoints require the `x-api-key` header. The collection inherits this from the folder-level auth config.\n\n## URL convention\nAll endpoints are user-scoped: `/:username/links`, `/:username/feed`, `/:username/api-keys`",
+    "description": "Personal bookmarking API (NestJS + Supabase) that publishes an RSS feed.\n\n## Setup\n1. Import the **Linkblog - Local** environment\n2. Set the `userApiKey` variable to your API key value (format: `lb_<64 hex chars>`)\n3. Set the `handle` variable to your profile handle\n4. Start the server: `pnpm start:dev`\n5. Run requests — the collection auto-captures `linkId` from create/list responses\n\n## Auth\nAll write endpoints require the `x-api-key` header. The collection inherits this from the folder-level auth config.\n\n## URL convention\nAll endpoints are user-scoped: `/:handle/links`, `/:handle/feed`, `/:handle/api-keys`",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "_exporter_id": "19671261"
   },
@@ -74,9 +74,9 @@
               "raw": "{\n  \"url\": \"https://example.com\",\n  \"title\": \"Should Not Work\"\n}"
             },
             "url": {
-              "raw": "{{baseUrl}}/{{username}}/links",
+              "raw": "{{baseUrl}}/{{handle}}/links",
               "host": ["{{baseUrl}}"],
-              "path": ["{{username}}", "links"]
+              "path": ["{{handle}}", "links"]
             },
             "description": "Attempt to create a link with no API key. Should return 401 Unauthorized."
           },
@@ -127,9 +127,9 @@
               "raw": "{\n  \"url\": \"https://example.com\",\n  \"title\": \"Should Not Work\"\n}"
             },
             "url": {
-              "raw": "{{baseUrl}}/{{username}}/links",
+              "raw": "{{baseUrl}}/{{handle}}/links",
               "host": ["{{baseUrl}}"],
-              "path": ["{{username}}", "links"]
+              "path": ["{{handle}}", "links"]
             },
             "description": "Attempt to create a link with an invalid API key. Should return 401 Unauthorized."
           },
@@ -189,9 +189,9 @@
               "raw": "{\n  \"url\": \"https://\",\n  \"title\": \"Should Not Work\"\n}"
             },
             "url": {
-              "raw": "{{baseUrl}}/{{username}}/links",
+              "raw": "{{baseUrl}}/{{handle}}/links",
               "host": ["{{baseUrl}}"],
-              "path": ["{{username}}", "links"]
+              "path": ["{{handle}}", "links"]
             },
             "description": "Attempt to create a link with an invalid API key. Should return 401 Unauthorized."
           },
@@ -280,9 +280,9 @@
               }
             },
             "url": {
-              "raw": "{{baseUrl}}/{{username}}/links",
+              "raw": "{{baseUrl}}/{{handle}}/links",
               "host": ["{{baseUrl}}"],
-              "path": ["{{username}}", "links"]
+              "path": ["{{handle}}", "links"]
             },
             "description": "Create a new bookmarked link. On success, auto-saves the returned `id` to `linkId`."
           },
@@ -322,9 +322,9 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/{{username}}/links",
+              "raw": "{{baseUrl}}/{{handle}}/links",
               "host": ["{{baseUrl}}"],
-              "path": ["{{username}}", "links"]
+              "path": ["{{handle}}", "links"]
             },
             "description": "Get all bookmarked links for the user, ordered newest first. Auto-saves the first link's `id` to `linkId`."
           },
@@ -364,9 +364,9 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/{{username}}/links/{{linkId}}",
+              "raw": "{{baseUrl}}/{{handle}}/links/{{linkId}}",
               "host": ["{{baseUrl}}"],
-              "path": ["{{username}}", "links", "{{linkId}}"]
+              "path": ["{{handle}}", "links", "{{linkId}}"]
             },
             "description": "Get a single link by ID. Uses `linkId` variable (auto-set by Create or List requests)."
           },
@@ -410,9 +410,9 @@
               "raw": "{\n  \"title\": \"Updated Title\",\n  \"summary\": \"Updated summary with new notes.\"\n}"
             },
             "url": {
-              "raw": "{{baseUrl}}/{{username}}/links/{{linkId}}",
+              "raw": "{{baseUrl}}/{{handle}}/links/{{linkId}}",
               "host": ["{{baseUrl}}"],
-              "path": ["{{username}}", "links", "{{linkId}}"]
+              "path": ["{{handle}}", "links", "{{linkId}}"]
             },
             "description": "Partially update a link. All body fields are optional. Uses `linkId` variable."
           },
@@ -440,9 +440,9 @@
             "method": "DELETE",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/{{username}}/links/{{linkId}}",
+              "raw": "{{baseUrl}}/{{handle}}/links/{{linkId}}",
               "host": ["{{baseUrl}}"],
-              "path": ["{{username}}", "links", "{{linkId}}"]
+              "path": ["{{handle}}", "links", "{{linkId}}"]
             },
             "description": "Delete a link by ID. Uses `linkId` variable. Clears `linkId` on success."
           },
@@ -506,9 +506,9 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/{{username}}/feed",
+              "raw": "{{baseUrl}}/{{handle}}/feed",
               "host": ["{{baseUrl}}"],
-              "path": ["{{username}}", "feed"]
+              "path": ["{{handle}}", "feed"]
             },
             "description": "Public RSS 2.0 feed of the user's links (newest first). No auth required."
           },
@@ -548,9 +548,9 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/{{username}}/api-keys",
+              "raw": "{{baseUrl}}/{{handle}}/api-keys",
               "host": ["{{baseUrl}}"],
-              "path": ["{{username}}", "api-keys"]
+              "path": ["{{handle}}", "api-keys"]
             },
             "description": "List all API keys for the authenticated user. Returns id, name, created_at, last_used_at — never the raw key or hash."
           },
@@ -608,9 +608,9 @@
               }
             },
             "url": {
-              "raw": "{{baseUrl}}/{{username}}/api-keys",
+              "raw": "{{baseUrl}}/{{handle}}/api-keys",
               "host": ["{{baseUrl}}"],
-              "path": ["{{username}}", "api-keys"]
+              "path": ["{{handle}}", "api-keys"]
             },
             "description": "Create a new API key. The `rawKey` field is returned only once — save it immediately. Auto-saves `apiKeyId`."
           },
@@ -638,9 +638,9 @@
             "method": "DELETE",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/{{username}}/api-keys/{{apiKeyId}}",
+              "raw": "{{baseUrl}}/{{handle}}/api-keys/{{apiKeyId}}",
               "host": ["{{baseUrl}}"],
-              "path": ["{{username}}", "api-keys", "{{apiKeyId}}"]
+              "path": ["{{handle}}", "api-keys", "{{apiKeyId}}"]
             },
             "description": "Delete an API key by ID. Uses `apiKeyId` variable. Clears `apiKeyId` on success."
           },
@@ -704,9 +704,9 @@
               "raw": "{\n  \"url\": \"https://example.com/workflow-test\",\n  \"title\": \"Workflow Test Link\",\n  \"summary\": \"Created by the CRUD workflow runner.\"\n}"
             },
             "url": {
-              "raw": "{{baseUrl}}/{{username}}/links",
+              "raw": "{{baseUrl}}/{{handle}}/links",
               "host": ["{{baseUrl}}"],
-              "path": ["{{username}}", "links"]
+              "path": ["{{handle}}", "links"]
             }
           },
           "response": []
@@ -735,9 +735,9 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/{{username}}/links/{{workflowLinkId}}",
+              "raw": "{{baseUrl}}/{{handle}}/links/{{workflowLinkId}}",
               "host": ["{{baseUrl}}"],
-              "path": ["{{username}}", "links", "{{workflowLinkId}}"]
+              "path": ["{{handle}}", "links", "{{workflowLinkId}}"]
             }
           },
           "response": []
@@ -775,9 +775,9 @@
               "raw": "{\n  \"title\": \"Workflow Test Link (Updated)\",\n  \"summary\": \"Updated by the CRUD workflow runner.\"\n}"
             },
             "url": {
-              "raw": "{{baseUrl}}/{{username}}/links/{{workflowLinkId}}",
+              "raw": "{{baseUrl}}/{{handle}}/links/{{workflowLinkId}}",
               "host": ["{{baseUrl}}"],
-              "path": ["{{username}}", "links", "{{workflowLinkId}}"]
+              "path": ["{{handle}}", "links", "{{workflowLinkId}}"]
             }
           },
           "response": []
@@ -811,9 +811,9 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/{{username}}/links/{{workflowLinkId}}",
+              "raw": "{{baseUrl}}/{{handle}}/links/{{workflowLinkId}}",
               "host": ["{{baseUrl}}"],
-              "path": ["{{username}}", "links", "{{workflowLinkId}}"]
+              "path": ["{{handle}}", "links", "{{workflowLinkId}}"]
             }
           },
           "response": []
@@ -837,9 +837,9 @@
             "method": "DELETE",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/{{username}}/links/{{workflowLinkId}}",
+              "raw": "{{baseUrl}}/{{handle}}/links/{{workflowLinkId}}",
               "host": ["{{baseUrl}}"],
-              "path": ["{{username}}", "links", "{{workflowLinkId}}"]
+              "path": ["{{handle}}", "links", "{{workflowLinkId}}"]
             }
           },
           "response": []
@@ -866,9 +866,9 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/{{username}}/links/{{workflowLinkId}}",
+              "raw": "{{baseUrl}}/{{handle}}/links/{{workflowLinkId}}",
               "host": ["{{baseUrl}}"],
-              "path": ["{{username}}", "links", "{{workflowLinkId}}"]
+              "path": ["{{handle}}", "links", "{{workflowLinkId}}"]
             }
           },
           "response": []
@@ -919,7 +919,7 @@
   ],
   "variable": [
     {
-      "key": "username",
+      "key": "handle",
       "value": "",
       "type": "default"
     }

--- a/src/api-keys/api-keys.controller.spec.ts
+++ b/src/api-keys/api-keys.controller.spec.ts
@@ -3,7 +3,7 @@ import { ApiKeysService } from "./api-keys.service";
 import { IS_PUBLIC_KEY } from "../auth/public.decorator";
 
 const USER_ID = "user-uuid-1";
-const USERNAME = "alice";
+const HANDLE = "alice";
 
 const mockApiKey = {
   id: "key-uuid-1",
@@ -36,7 +36,7 @@ describe("ApiKeysController", () => {
 
       const result = await controller.findAll({
         userId: USER_ID,
-        username: USERNAME,
+        handle: HANDLE,
       });
 
       expect(service.findAll).toHaveBeenCalledWith(USER_ID);
@@ -52,7 +52,7 @@ describe("ApiKeysController", () => {
       const dto = { name: "My Key" };
       const result = await controller.create(dto, {
         userId: USER_ID,
-        username: USERNAME,
+        handle: HANDLE,
       });
 
       expect(service.create).toHaveBeenCalledWith(dto, USER_ID);
@@ -66,7 +66,7 @@ describe("ApiKeysController", () => {
 
       const result = await controller.remove("key-uuid-1", {
         userId: USER_ID,
-        username: USERNAME,
+        handle: HANDLE,
       });
 
       expect(service.remove).toHaveBeenCalledWith("key-uuid-1", USER_ID);

--- a/src/api-keys/api-keys.controller.ts
+++ b/src/api-keys/api-keys.controller.ts
@@ -6,16 +6,16 @@ import { CurrentUser } from "../auth/current-user.decorator.js";
 
 interface AuthUser {
   userId: string;
-  username: string;
+  handle: string;
 }
 
 @ApiTags("API Keys")
 @ApiParam({
-  name: "username",
-  description: "The username of the API key owner",
+  name: "handle",
+  description: "The handle of the API key owner",
 })
 @ApiSecurity("api-key")
-@Controller(":username/api-keys")
+@Controller(":handle/api-keys")
 export class ApiKeysController {
   constructor(private readonly apiKeysService: ApiKeysService) {}
 

--- a/src/auth/api-key.guard.spec.ts
+++ b/src/auth/api-key.guard.spec.ts
@@ -15,7 +15,7 @@ describe("ApiKeyGuard", () => {
   const RAW_KEY = "lb_" + "a".repeat(64);
   const KEY_HASH = createHash("sha256").update(RAW_KEY).digest("hex");
   const USER_ID = "user-uuid-1";
-  const USERNAME = "alice";
+  const HANDLE = "alice";
 
   function buildSupabaseMock(opts: {
     apiKeyRow?: Record<string, unknown> | null;
@@ -26,7 +26,7 @@ describe("ApiKeyGuard", () => {
     const {
       apiKeyRow = { user_id: USER_ID },
       apiKeyError = null,
-      profileRow = { username: USERNAME },
+      profileRow = { handle: HANDLE },
       profileError = null,
     } = opts;
 
@@ -142,11 +142,11 @@ describe("ApiKeyGuard", () => {
     await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
   });
 
-  it("should throw 403 when username param does not match key owner", async () => {
+  it("should throw 403 when handle param does not match key owner", async () => {
     vi.spyOn(reflector, "getAllAndOverride").mockReturnValue(false);
     const ctx = createMockContext({
       headers: { "x-api-key": RAW_KEY },
-      params: { username: "bob" }, // key belongs to 'alice'
+      params: { handle: "bob" }, // key belongs to 'alice'
     });
 
     await expect(guard.canActivate(ctx)).rejects.toThrow(ForbiddenException);
@@ -155,21 +155,21 @@ describe("ApiKeyGuard", () => {
     );
   });
 
-  it("should attach request.user and return true for valid key with matching username", async () => {
+  it("should attach request.user and return true for valid key with matching handle", async () => {
     vi.spyOn(reflector, "getAllAndOverride").mockReturnValue(false);
     const ctx = createMockContext({
       headers: { "x-api-key": RAW_KEY },
-      params: { username: USERNAME },
+      params: { handle: HANDLE },
     });
     const req = ctx.switchToHttp().getRequest();
 
     const result = await guard.canActivate(ctx);
 
     expect(result).toBe(true);
-    expect(req.user).toEqual({ userId: USER_ID, username: USERNAME });
+    expect(req.user).toEqual({ userId: USER_ID, handle: HANDLE });
   });
 
-  it("should attach request.user and return true when no username param (non-user-scoped route)", async () => {
+  it("should attach request.user and return true when no handle param (non-user-scoped route)", async () => {
     vi.spyOn(reflector, "getAllAndOverride").mockReturnValue(false);
     const ctx = createMockContext({
       headers: { "x-api-key": RAW_KEY },
@@ -180,7 +180,7 @@ describe("ApiKeyGuard", () => {
     const result = await guard.canActivate(ctx);
 
     expect(result).toBe(true);
-    expect(req.user).toEqual({ userId: USER_ID, username: USERNAME });
+    expect(req.user).toEqual({ userId: USER_ID, handle: HANDLE });
   });
 
   it("should update last_used_at asynchronously (fire-and-forget)", async () => {
@@ -195,7 +195,7 @@ describe("ApiKeyGuard", () => {
       error: null,
     });
     const singleProfileMock = vi.fn().mockResolvedValue({
-      data: { username: USERNAME },
+      data: { handle: HANDLE },
       error: null,
     });
 
@@ -219,7 +219,7 @@ describe("ApiKeyGuard", () => {
 
     const ctx = createMockContext({
       headers: { "x-api-key": RAW_KEY },
-      params: { username: USERNAME },
+      params: { handle: HANDLE },
     });
 
     await guard.canActivate(ctx);

--- a/src/auth/api-key.guard.ts
+++ b/src/auth/api-key.guard.ts
@@ -51,10 +51,10 @@ export class ApiKeyGuard implements CanActivate {
 
     const userId: string = apiKeyRow.user_id;
 
-    // Resolve the username for this user
+    // Resolve the handle for this user
     const { data: profileRow, error: profileError } = await this.supabase
       .from("profiles")
-      .select("username")
+      .select("handle")
       .eq("id", userId)
       .single();
 
@@ -62,17 +62,17 @@ export class ApiKeyGuard implements CanActivate {
       throw new UnauthorizedException("Invalid API key");
     }
 
-    const username: string = profileRow.username;
+    const handle: string = profileRow.handle;
 
-    // If there is a :username param in the URL, verify the key owner matches
-    const usernameParam: string | undefined =
-      request.params?.username?.toLowerCase();
-    if (usernameParam && usernameParam !== username) {
+    // If there is a :handle param in the URL, verify the key owner matches
+    const handleParam: string | undefined =
+      request.params?.handle?.toLowerCase();
+    if (handleParam && handleParam !== handle) {
       throw new ForbiddenException("API key does not match the requested user");
     }
 
     // Attach user to the request
-    request.user = { userId, username };
+    request.user = { userId, handle };
 
     // Fire-and-forget: update last_used_at asynchronously
     void this.supabase

--- a/src/auth/current-user.decorator.spec.ts
+++ b/src/auth/current-user.decorator.spec.ts
@@ -36,7 +36,7 @@ describe("@CurrentUser() decorator", () => {
   const extract = getDecoratorFactory(CurrentUser);
 
   it("returns request.user when set", () => {
-    const user = { userId: "abc-123", username: "vid" };
+    const user = { userId: "abc-123", handle: "vid" };
     const ctx = createMockContext(user);
 
     expect(extract(ctx)).toEqual(user);
@@ -49,11 +49,11 @@ describe("@CurrentUser() decorator", () => {
   });
 
   it("returns the full user object shape", () => {
-    const user = { userId: "uuid-here", username: "alice" };
+    const user = { userId: "uuid-here", handle: "alice" };
     const ctx = createMockContext(user);
     const result = extract(ctx) as typeof user;
 
     expect(result.userId).toBe("uuid-here");
-    expect(result.username).toBe("alice");
+    expect(result.handle).toBe("alice");
   });
 });

--- a/src/auth/current-user.decorator.ts
+++ b/src/auth/current-user.decorator.ts
@@ -2,7 +2,7 @@ import { createParamDecorator, ExecutionContext } from "@nestjs/common";
 //
 export interface CurrentUserPayload {
   userId: string;
-  username: string;
+  handle: string;
 }
 
 /**

--- a/src/feed/feed.controller.spec.ts
+++ b/src/feed/feed.controller.spec.ts
@@ -4,9 +4,9 @@ import { UsersService, UserProfile } from "../users/users.service.js";
 import { IS_PUBLIC_KEY } from "../auth/public.decorator";
 
 const USER_ID = "user-uuid-1";
-const USERNAME = "alice";
+const HANDLE = "alice";
 
-const mockUser: UserProfile = { id: USER_ID, username: USERNAME };
+const mockUser: UserProfile = { id: USER_ID, handle: HANDLE };
 
 describe("FeedController", () => {
   let controller: FeedController;
@@ -19,7 +19,7 @@ describe("FeedController", () => {
     } as unknown as FeedService;
 
     usersService = {
-      findByUsername: vi.fn().mockResolvedValue(mockUser),
+      findByHandle: vi.fn().mockResolvedValue(mockUser),
     } as unknown as UsersService;
 
     controller = new FeedController(feedService, usersService);
@@ -30,14 +30,11 @@ describe("FeedController", () => {
   });
 
   describe("getFeed", () => {
-    it("should resolve username and delegate to FeedService.generateRssFeed", async () => {
-      const result = await controller.getFeed(USERNAME);
+    it("should resolve handle and delegate to FeedService.generateRssFeed", async () => {
+      const result = await controller.getFeed(HANDLE);
 
-      expect(usersService.findByUsername).toHaveBeenCalledWith(USERNAME);
-      expect(feedService.generateRssFeed).toHaveBeenCalledWith(
-        USER_ID,
-        USERNAME,
-      );
+      expect(usersService.findByHandle).toHaveBeenCalledWith(HANDLE);
+      expect(feedService.generateRssFeed).toHaveBeenCalledWith(USER_ID, HANDLE);
       expect(result).toBe("<rss/>");
     });
   });

--- a/src/feed/feed.controller.ts
+++ b/src/feed/feed.controller.ts
@@ -29,10 +29,10 @@ const RSS_EXAMPLE = `<?xml version="1.0" encoding="utf-8"?>
 
 @ApiTags("Feed")
 @ApiParam({
-  name: "username",
-  description: "The username whose feed to retrieve",
+  name: "handle",
+  description: "The handle whose feed to retrieve",
 })
-@Controller(":username/feed")
+@Controller(":handle/feed")
 export class FeedController {
   constructor(
     private readonly feedService: FeedService,
@@ -53,8 +53,8 @@ export class FeedController {
     },
   })
   @ApiNotFoundResponse({ description: "User not found" })
-  async getFeed(@Param("username") username: string): Promise<string> {
-    const profile = await this.usersService.findByUsername(username);
-    return this.feedService.generateRssFeed(profile.id, username);
+  async getFeed(@Param("handle") handle: string): Promise<string> {
+    const profile = await this.usersService.findByHandle(handle);
+    return this.feedService.generateRssFeed(profile.id, handle);
   }
 }

--- a/src/feed/feed.service.spec.ts
+++ b/src/feed/feed.service.spec.ts
@@ -3,7 +3,7 @@ import { LinksService } from "../links/links.service";
 import { FeedService } from "./feed.service";
 
 const USER_ID = "user-uuid-1";
-const USERNAME = "alice";
+const HANDLE = "alice";
 
 const mockLink = {
   id: 1,
@@ -37,27 +37,27 @@ describe("FeedService", () => {
 
   describe("generateRssFeed", () => {
     it("should call linksService.findAll with the given userId", async () => {
-      await service.generateRssFeed(USER_ID, USERNAME);
+      await service.generateRssFeed(USER_ID, HANDLE);
 
       expect(linksService.findAll).toHaveBeenCalledWith(USER_ID);
     });
 
     it("should return a string of RSS XML", async () => {
-      const result = await service.generateRssFeed(USER_ID, USERNAME);
+      const result = await service.generateRssFeed(USER_ID, HANDLE);
 
       expect(typeof result).toBe("string");
       expect(result).toContain("<rss");
       expect(result).toContain("<channel>");
     });
 
-    it("should include the username in the feed title", async () => {
-      const result = await service.generateRssFeed(USER_ID, USERNAME);
+    it("should include the handle in the feed title", async () => {
+      const result = await service.generateRssFeed(USER_ID, HANDLE);
 
-      expect(result).toContain(USERNAME);
+      expect(result).toContain(HANDLE);
     });
 
     it("should include link items in the feed", async () => {
-      const result = await service.generateRssFeed(USER_ID, USERNAME);
+      const result = await service.generateRssFeed(USER_ID, HANDLE);
 
       expect(result).toContain("https://example.com");
     });
@@ -65,7 +65,7 @@ describe("FeedService", () => {
     it("should return a valid feed with no items when links list is empty", async () => {
       vi.mocked(linksService.findAll).mockResolvedValue([]);
 
-      const result = await service.generateRssFeed(USER_ID, USERNAME);
+      const result = await service.generateRssFeed(USER_ID, HANDLE);
 
       expect(result).toContain("<channel>");
     });

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -9,7 +9,7 @@ export class FeedService {
     private readonly configService: ConfigService,
   ) {}
 
-  async generateRssFeed(userId: string, username: string): Promise<string> {
+  async generateRssFeed(userId: string, handle: string): Promise<string> {
     const { Feed } = await import("feed");
     const links = await this.linksService.findAll(userId);
 
@@ -17,10 +17,10 @@ export class FeedService {
       "API_URL",
       "https://api.linkblog.in",
     );
-    const feedUrl = `${appUrl}/${username}/feed`;
+    const feedUrl = `${appUrl}/${handle}/feed`;
 
     const feed = new Feed({
-      title: `${username}'s Linkblog`,
+      title: `${handle}'s Linkblog`,
       description: "Things that I found interesting",
       id: feedUrl,
       link: feedUrl,

--- a/src/links/links.controller.spec.ts
+++ b/src/links/links.controller.spec.ts
@@ -4,9 +4,9 @@ import { UsersService, UserProfile } from "../users/users.service.js";
 import { IS_PUBLIC_KEY } from "../auth/public.decorator";
 
 const USER_ID = "user-uuid-1";
-const USERNAME = "alice";
+const HANDLE = "alice";
 
-const mockUser: UserProfile = { id: USER_ID, username: USERNAME };
+const mockUser: UserProfile = { id: USER_ID, handle: HANDLE };
 
 const mockLink = {
   id: 1,
@@ -33,7 +33,7 @@ describe("LinksController", () => {
     } as unknown as LinksService;
 
     usersService = {
-      findByUsername: vi.fn().mockResolvedValue(mockUser),
+      findByHandle: vi.fn().mockResolvedValue(mockUser),
     } as unknown as UsersService;
 
     controller = new LinksController(linksService, usersService);
@@ -50,7 +50,7 @@ describe("LinksController", () => {
       const dto = { url: "https://example.com", title: "Example" };
       const result = await controller.create(dto, {
         userId: USER_ID,
-        username: USERNAME,
+        handle: HANDLE,
       });
 
       expect(result).toEqual(mockLink);
@@ -59,24 +59,24 @@ describe("LinksController", () => {
   });
 
   describe("findAll", () => {
-    it("should resolve username to userId and delegate to LinksService.findAll", async () => {
+    it("should resolve handle to userId and delegate to LinksService.findAll", async () => {
       vi.mocked(linksService.findAll).mockResolvedValue([mockLink]);
 
-      const result = await controller.findAll(USERNAME);
+      const result = await controller.findAll(HANDLE);
 
-      expect(usersService.findByUsername).toHaveBeenCalledWith(USERNAME);
+      expect(usersService.findByHandle).toHaveBeenCalledWith(HANDLE);
       expect(linksService.findAll).toHaveBeenCalledWith(USER_ID);
       expect(result).toEqual([mockLink]);
     });
   });
 
   describe("findOne", () => {
-    it("should resolve username to userId and delegate to LinksService.findOne", async () => {
+    it("should resolve handle to userId and delegate to LinksService.findOne", async () => {
       vi.mocked(linksService.findOne).mockResolvedValue(mockLink);
 
-      const result = await controller.findOne(USERNAME, "1");
+      const result = await controller.findOne(HANDLE, "1");
 
-      expect(usersService.findByUsername).toHaveBeenCalledWith(USERNAME);
+      expect(usersService.findByHandle).toHaveBeenCalledWith(HANDLE);
       expect(linksService.findOne).toHaveBeenCalledWith(1, USER_ID);
       expect(result).toEqual(mockLink);
     });
@@ -90,7 +90,7 @@ describe("LinksController", () => {
       const dto = { title: "Updated" };
       const result = await controller.update("1", dto, {
         userId: USER_ID,
-        username: USERNAME,
+        handle: HANDLE,
       });
 
       expect(linksService.update).toHaveBeenCalledWith(1, dto, USER_ID);
@@ -104,7 +104,7 @@ describe("LinksController", () => {
 
       const result = await controller.remove("1", {
         userId: USER_ID,
-        username: USERNAME,
+        handle: HANDLE,
       });
 
       expect(linksService.remove).toHaveBeenCalledWith(1, USER_ID);

--- a/src/links/links.controller.ts
+++ b/src/links/links.controller.ts
@@ -26,13 +26,13 @@ import { CurrentUser } from "../auth/current-user.decorator.js";
 
 interface AuthUser {
   userId: string;
-  username: string;
+  handle: string;
 }
 
 @ApiTags("Links")
-@ApiParam({ name: "username", description: "The username of the link owner" })
+@ApiParam({ name: "handle", description: "The handle of the link owner" })
 @ApiSecurity("api-key")
-@Controller(":username/links")
+@Controller(":handle/links")
 export class LinksController {
   constructor(
     private readonly linksService: LinksService,
@@ -54,8 +54,8 @@ export class LinksController {
     description: "List of all links for the user",
     type: [LinkResponseDto],
   })
-  async findAll(@Param("username") username: string) {
-    const profile = await this.usersService.findByUsername(username);
+  async findAll(@Param("handle") handle: string) {
+    const profile = await this.usersService.findByHandle(handle);
     return this.linksService.findAll(profile.id);
   }
 
@@ -66,8 +66,8 @@ export class LinksController {
     type: LinkResponseDto,
   })
   @ApiNotFoundResponse({ description: "Link not found" })
-  async findOne(@Param("username") username: string, @Param("id") id: string) {
-    const profile = await this.usersService.findByUsername(username);
+  async findOne(@Param("handle") handle: string, @Param("id") id: string) {
+    const profile = await this.usersService.findByHandle(handle);
     return this.linksService.findOne(+id, profile.id);
   }
 

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -8,7 +8,7 @@ import { SUPABASE_CLIENT } from "../supabase/supabase.module.js";
 
 const mockProfile = {
   id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-  username: "vid",
+  handle: "vid",
 };
 
 function createMockSupabase() {
@@ -42,28 +42,28 @@ describe("UsersService", () => {
     expect(service).toBeDefined();
   });
 
-  describe("findByUsername", () => {
-    it("should return the user profile for a known username", async () => {
+  describe("findByHandle", () => {
+    it("should return the user profile for a known handle", async () => {
       supabase.single.mockResolvedValue({ data: mockProfile, error: null });
 
-      const result = await service.findByUsername("vid");
+      const result = await service.findByHandle("vid");
 
       expect(result).toEqual(mockProfile);
       expect(supabase.from).toHaveBeenCalledWith("profiles");
-      expect(supabase.select).toHaveBeenCalledWith("id, username");
-      expect(supabase.eq).toHaveBeenCalledWith("username", "vid");
+      expect(supabase.select).toHaveBeenCalledWith("id, handle");
+      expect(supabase.eq).toHaveBeenCalledWith("handle", "vid");
     });
 
-    it("should throw NotFoundException for an unknown username", async () => {
+    it("should throw NotFoundException for an unknown handle", async () => {
       supabase.single.mockResolvedValue({
         data: null,
         error: { code: "PGRST116", message: "not found" },
       });
 
-      await expect(service.findByUsername("nobody")).rejects.toThrow(
+      await expect(service.findByHandle("nobody")).rejects.toThrow(
         NotFoundException,
       );
-      await expect(service.findByUsername("nobody")).rejects.toThrow(
+      await expect(service.findByHandle("nobody")).rejects.toThrow(
         "User 'nobody' not found",
       );
     });
@@ -74,7 +74,7 @@ describe("UsersService", () => {
         error: { code: "PGRST500", message: "unexpected db error" },
       });
 
-      await expect(service.findByUsername("vid")).rejects.toThrow(
+      await expect(service.findByHandle("vid")).rejects.toThrow(
         InternalServerErrorException,
       );
     });

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -9,7 +9,7 @@ import { SUPABASE_CLIENT } from "../supabase/supabase.module.js";
 
 export interface UserProfile {
   id: string;
-  username: string;
+  handle: string;
 }
 
 @Injectable()
@@ -18,16 +18,16 @@ export class UsersService {
     @Inject(SUPABASE_CLIENT) private readonly supabase: SupabaseClient,
   ) {}
 
-  async findByUsername(username: string): Promise<UserProfile> {
+  async findByHandle(handle: string): Promise<UserProfile> {
     const { data, error } = await this.supabase
       .from("profiles")
-      .select("id, username")
-      .eq("username", username.toLowerCase())
+      .select("id, handle")
+      .eq("handle", handle.toLowerCase())
       .single();
 
     if (error) {
       if (error.code === "PGRST116") {
-        throw new NotFoundException(`User '${username}' not found`);
+        throw new NotFoundException(`User '${handle}' not found`);
       }
       throw new InternalServerErrorException(error.message);
     }

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -153,7 +153,11 @@ enabled = true
 # in emails.
 site_url = "http://127.0.0.1:3000"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://127.0.0.1:3000"]
+additional_redirect_urls = [
+  "https://127.0.0.1:3000",
+  "http://127.0.0.1:3000",
+  "http://127.0.0.1:3000",
+]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).

--- a/supabase/migrations/20260304141015_rename_username_to_handle_add_trigger_and_rls_policies.sql
+++ b/supabase/migrations/20260304141015_rename_username_to_handle_add_trigger_and_rls_policies.sql
@@ -1,0 +1,37 @@
+-- 1. Rename the column (username is confusing, since we're not using this to let people login)
+alter table public.profiles
+  rename column username to handle;
+
+-- 2. Rename the index to match (old one still works but naming matters for clarity)
+alter index profiles_username_idx
+  rename to profiles_handle_idx;
+
+-- 3. Trigger function: auto-provisions a profile when a user signs up
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.profiles (id, handle)
+  values (
+    new.id,
+    'user_' || left(replace(new.id::text, '-', ''), 8)
+  );
+  return new;
+end;
+$$;
+
+-- 4. Trigger: fires after every INSERT on auth.users
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row
+  execute procedure public.handle_new_user();
+
+-- 5. RLS: users can update their own profile (e.g. change their handle)
+create policy "Users can update their own profile"
+  on public.profiles
+  for update
+  using (auth.uid() = id)
+  with check (auth.uid() = id);

--- a/supabase/snippets/Untitled query 736.sql
+++ b/supabase/snippets/Untitled query 736.sql
@@ -1,0 +1,1 @@
+update links set user_id ='308e5f88-83dd-4011-a3f9-ad445eeb1fdf'


### PR DESCRIPTION
Summary- Rename profile field "username" to "handle" across database, API, services, tests, docs, and browser extension defaults.
- Add DB trigger and function to auto-provision a minimal profile when a new auth.user is created, generating a stable handle like "user_<first8chars_of_id>".
- Add row-level security policy allowing users to update only their own profile (auth.uid() = id).
- Update feed route and RSS generation to use /:handle/feed and select/query handle.
- Add localhost redirect URLs (http and https) to supabase/config.toml for local auth callback testing.

Related- Commits: feat(db): rename username to handle and add auto-provisioning; refactor: rename username -> handle across API and tests; fix(auth): add localhost redirect URLs for auth callbacksNotes- Field rename clarifies that the value is not used for login and aligns naming across front-end, API, services, and docs.
- Auto-provisioning ensures new users get a stable default handle.
- RLS policy scopes profile updates to the owning user.