### PR TITLE
chore(config): set production site_url for auth redirectsUpdate Supabase config.toml to change site_url from thelocal development address to the production API domain.

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -151,7 +151,7 @@ max_indexes = 5
 enabled = true
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
 # in emails.
-site_url = "http://127.0.0.1:3000"
+site_url = "https://api.linkblog.app"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
 additional_redirect_urls = [
   "https://127.0.0.1:3000",


### PR DESCRIPTION
This ensures generated URLs (for emails and OAuth redirects)
use https://api.linkblog.app and aligns the auth redirectallow-list with the deployed environment.