### PR TITLE
fix/update-site-url-local-dev

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Linkblog Service - This the API for Linkblog, a linkblog service.
 - **Endpoints:** `/:handle/links` (CRUD; reads public, writes protected), `/:handle/feed` (public RSS 2.0), `/:handle/api-keys` (key management, protected), `/health` (public), `/api-docs` (Swagger UI)
 - **Auth:** Multi-user, global `ApiKeyGuard` via `APP_GUARD`. Write endpoints require `x-api-key` header (per-user keys stored as SHA-256 hashes in `api_keys` table). Public routes use `@Public()` decorator to opt out. See `src/auth/`.
 - **Data model:** Supabase tables: `links` (id, url, title, summary, user_id, created_at, updated_at), `profiles` (id, handle), `api_keys` (id, user_id, name, key_hash, created_at, last_used_at), `app_config` (key, value)
-- **Deploy:** AWS App Runner (manual console config; `apprunner.yaml` is reference only). Production URL: `api.linkblog.in`
+- **Deploy:** AWS App Runner (manual console config; `apprunner.yaml` is reference only). Production URL: `api.linklog.app`
 
 ## Commands
 

--- a/apprunner.yaml
+++ b/apprunner.yaml
@@ -24,4 +24,4 @@ run:
     - name: SUPABASE_SERVICE_ROLE_KEY
       value: "jdfkjfkdljdflkjfdlkjfkdljk"
     - name: API_URL
-      value: "https://api.linkblog.in"
+      value: "https://api.linklog.app"

--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -84,7 +84,7 @@ browser-extension/
 
 ## API
 
-The extension POSTs to your linkblog API endpoint (default: `https://api.linkblog.in/links`).
+The extension POSTs to your linkblog API endpoint (default: `https://api.linklog.app/links`).
 
 **Success response:**
 

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -1,10 +1,10 @@
 {
   "manifest_version": 3,
-  "name": "Linkblog",
+  "name": "Linklog",
   "version": "1.0.2",
   "description": "Save links to your linkblog with one click, right-click, or keyboard shortcut",
   "permissions": ["activeTab", "storage", "contextMenus", "notifications"],
-  "host_permissions": ["https://api.linkblog.in/*"],
+  "host_permissions": ["https://api.linklog.app/*"],
   "action": {
     "default_popup": "popup/popup.html",
     "default_icon": {

--- a/browser-extension/src/popup/popup.html
+++ b/browser-extension/src/popup/popup.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Linkblog</title>
+    <title>Linklog</title>
     <link rel="stylesheet" href="popup.css" />
   </head>
   <body>
     <div class="container">
-      <h1>Linkblog</h1>
+      <h1>Linklog</h1>
 
       <div id="status-section" class="section">
         <div id="current-url" class="url-display">Loading...</div>
@@ -27,7 +27,7 @@
           rows="3"
         ></textarea>
 
-        <button id="save-btn" class="btn btn-primary">Save to Linkblog</button>
+        <button id="save-btn" class="btn btn-primary">Save to Linklog</button>
         <div id="status-message" class="status-message hidden"></div>
       </div>
 
@@ -88,7 +88,7 @@
         <input
           type="url"
           id="api-endpoint"
-          placeholder="https://api.linkblog.in/links"
+          placeholder="https://api.linklog.app/links"
         />
 
         <button id="save-settings-btn" class="btn btn-secondary">

--- a/browser-extension/src/types/index.ts
+++ b/browser-extension/src/types/index.ts
@@ -32,8 +32,8 @@ export interface ExtensionSettings {
 }
 
 // Default endpoint placeholder — users must replace {your-handle} with their actual handle.
-// Format: https://api.linkblog.in/{your-handle}/links
+// Format: https://api.linklog.app/{your-handle}/links
 export const DEFAULT_SETTINGS: ExtensionSettings = {
   apiKey: "",
-  apiEndpoint: "https://api.linkblog.in/{your-handle}/links",
+  apiEndpoint: "https://api.linklog.app/{your-handle}/links",
 };

--- a/github_pages/_data/navigation.yml
+++ b/github_pages/_data/navigation.yml
@@ -14,7 +14,7 @@ main:
   - title: "Edge Functions"
     url: /edge-functions
   - title: "API Docs"
-    url: https://api.linkblog.in/docs
+    url: https://api.linklog.app/docs
 
 docs:
   - title: "Getting Started"

--- a/github_pages/api.md
+++ b/github_pages/api.md
@@ -5,11 +5,11 @@ permalink: /api/
 toc: true
 ---
 
-Base URL: `http://localhost:3000` (local) or `https://api.linkblog.in` (production).
+Base URL: `http://localhost:3000` (local) or `https://api.linklog.app` (production).
 
 > **Tip:** A ready-to-use Postman collection is available in `postman/Linkblog API.postman_collection.json` with pre-built requests, test scripts, and a CRUD workflow runner. See [Getting Started](getting-started#using-postman) for setup.
 
-> **Interactive docs:** Visit [`/docs`](https://api.linkblog.in/docs) for the Swagger UI with all endpoints, schemas, and a "Try it out" feature.
+> **Interactive docs:** Visit [`/docs`](https://api.linklog.app/docs) for the Swagger UI with all endpoints, schemas, and a "Try it out" feature.
 
 ## Authentication
 
@@ -236,7 +236,7 @@ curl http://localhost:3000/alice/feed
 <rss version="2.0">
   <channel>
     <title>alice's Linkblog</title>
-    <link>https://api.linkblog.in/alice/feed</link>
+    <link>https://api.linklog.app/alice/feed</link>
     <description>alice's Linkblog Feed</description>
     <item>
       <title>Interesting Article</title>

--- a/github_pages/browser-extension.md
+++ b/github_pages/browser-extension.md
@@ -49,7 +49,7 @@ pnpm clean:extension && pnpm build:extension
 Click the Linkblog extension icon to open the popup. Scroll to the **Settings** section:
 
 1. **API Key** — enter your `x-api-key` value (the raw key starting with `lb_`)
-2. **API Endpoint** — set to your links endpoint, e.g. `https://api.linkblog.in/alice/links` (replace `alice` with your handle)
+2. **API Endpoint** — set to your links endpoint, e.g. `https://api.linklog.app/alice/links` (replace `alice` with your handle)
 3. Click **Save Settings**
 
 Settings are stored in `browser.storage.sync` and persist across browser sessions.
@@ -118,4 +118,4 @@ The extension requests:
 - `storage` — persist API key and endpoint settings
 - `contextMenus` — add "Save to Linkblog" to right-click menu
 - `notifications` — show save confirmation notifications
-- `host_permissions` for `https://api.linkblog.in/*` — make API requests
+- `host_permissions` for `https://api.linklog.app/*` — make API requests

--- a/github_pages/deployment.md
+++ b/github_pages/deployment.md
@@ -52,7 +52,7 @@ docker build -t linkblog .
 docker run -p 3000:3000 \
   -e SUPABASE_URL=https://your-project.supabase.co \
   -e SUPABASE_SERVICE_ROLE_KEY=your-service-role-key \
-  -e API_URL=https://api.linkblog.in \
+  -e API_URL=https://api.linklog.app \
   linkblog
 ```
 
@@ -99,7 +99,7 @@ To use a custom domain with App Runner:
 3. Create the DNS records (CNAME) as instructed
 4. Wait for certificate validation
 
-The production API is at `api.linkblog.in`.
+The production API is at `api.linklog.app`.
 
 ## CI/CD
 

--- a/github_pages/getting-started.md
+++ b/github_pages/getting-started.md
@@ -26,7 +26,7 @@ Create a `.env` file in the project root:
 ```env
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
-API_URL=https://api.linkblog.in
+API_URL=https://api.linklog.app
 PORT=3000
 ```
 

--- a/github_pages/index.md
+++ b/github_pages/index.md
@@ -25,7 +25,7 @@ Example at: [Vid Luther](https://luther.io/)
 - [Deployment](deployment) -- Ship to AWS App Runner
 - [Browser Extension](browser-extension) -- Chrome/Safari extension docs
 - [Edge Functions](edge-functions) -- Supabase Edge Function docs
-- [API Docs (Swagger)](https://api.linkblog.in/docs) -- Interactive API documentation
+- [API Docs (Swagger)](https://api.linklog.app/docs) -- Interactive API documentation
 
 ## Tech Stack
 

--- a/src/feed/feed.controller.ts
+++ b/src/feed/feed.controller.ts
@@ -14,7 +14,7 @@ const RSS_EXAMPLE = `<?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0">
   <channel>
     <title>jdoe's Linkblog</title>
-    <link>https://api.linkblog.in/jdoe/feed</link>
+    <link>https://api.linklog.app/jdoe/feed</link>
     <description>Things that I found interesting</description>
     <language>en</language>
     <generator>Linkblog</generator>

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -15,7 +15,7 @@ export class FeedService {
 
     const appUrl = this.configService.get<string>(
       "API_URL",
-      "https://api.linkblog.in",
+      "https://api.linklog.app",
     );
     const feedUrl = `${appUrl}/${handle}/feed`;
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -151,7 +151,7 @@ max_indexes = 5
 enabled = true
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
 # in emails.
-site_url = "https://api.linkblog.app"
+site_url = "http://127.0.0.1:3000"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
 additional_redirect_urls = [
   "https://127.0.0.1:3000",

--- a/supabase/functions/fetch-metadata/metadata-extractor.ts
+++ b/supabase/functions/fetch-metadata/metadata-extractor.ts
@@ -2,7 +2,7 @@ import { parseHTML } from "linkedom";
 
 const FETCH_TIMEOUT_MS = 10_000;
 const MAX_RESPONSE_BYTES = 5_000_000;
-const USER_AGENT = "Dogmatix/1.0 (+https://api.linkblog.in)";
+const USER_AGENT = "Dogmatix/1.0 (+https://api.linklog.app)";
 const MAX_TITLE_LENGTH = 500;
 const MAX_DESCRIPTION_LENGTH = 1000;
 


### PR DESCRIPTION
- Update site_url configuration to use local development server for correct auth redirects and email links during local testing.
- Replace all instances of the old domain linkblog.in with the new domain linklog.app in code, docs, extensions, and config files.
- Update user-facing labels and examples to reflect the Linklog branding and ensure consistent use of the new production domain.