### PR TITLE
fix: use standard Supabase service role env key

### DIFF
--- a/supabase/functions/fetch-metadata/index.ts
+++ b/supabase/functions/fetch-metadata/index.ts
@@ -31,15 +31,15 @@ Deno.serve(async (req: Request) => {
   console.log("[params] limit=%d, link_id=%s", limit, linkIdParam ?? "none");
 
   const supabaseUrl = Deno.env.get("SUPABASE_URL");
-  const secretKey = Deno.env.get("SB_SERVICE_ROLE_KEY");
+  const secretKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
 
   console.log("[env] SUPABASE_URL present:", !!supabaseUrl);
-  console.log("[env] SB_SERVICE_ROLE_KEY present:", !!secretKey);
+  console.log("[env] SUPABASE_SERVICE_ROLE_KEY present:", !!secretKey);
 
   if (!supabaseUrl || !secretKey) {
     return new Response(
       JSON.stringify({
-        error: "SUPABASE_URL or SB_SERVICE_ROLE_KEY not configured",
+        error: "SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY not configured",
       }),
       { status: 500, headers: { "Content-Type": "application/json" } },
     );


### PR DESCRIPTION
Read SUPABASE_SERVICE_ROLE_KEY instead of the old
SB_SERVICE_ROLE_KEY in fetch-metadata.

Update the environment presence logs and error message to use
the same variable name so diagnostics stay accurate.

Do this to match Supabase's standard configuration and prevent
the function from failing when only the expected env key is set.