### PR TITLE
refactor: remove when clause from metadata fetch trigger

### DIFF
--- a/supabase/migrations/20260426052211_drop_fetch_metadata_when_clause.sql
+++ b/supabase/migrations/20260426052211_drop_fetch_metadata_when_clause.sql
@@ -1,0 +1,10 @@
+-- Fire the metadata fetcher on every link insert.
+-- Previously gated on (NEW.title IS NULL OR NEW.title = ''); the edge
+-- function now owns the decision of whether/what to update.
+
+drop trigger if exists on_link_insert_fetch_metadata on public.links;
+
+create trigger on_link_insert_fetch_metadata
+  after insert on public.links
+  for each row
+  execute function public.notify_fetch_metadata();


### PR DESCRIPTION
Drop the conditional when clause from the metadata fetcher
trigger. The edge function now owns the decision of whether
and what metadata to update, simplifying the trigger logic
and centralizing update decisions in the application layer.

closes #99